### PR TITLE
Add an option to toggle the hardware acceleration

### DIFF
--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -99,6 +99,10 @@ class GeneralTab extends Component {
                 h(PreferencesItem, {
                     id: 'gtp.start_game_after_attach',
                     text: 'Start game right after attaching engines'
+                }),
+                h(PreferencesItem, {
+                    id: 'app.enable_hardware_acceleration',
+                    text: 'Enable hardware acceleration'
                 })
             ),
 

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,10 @@ let windows = []
 let openfile = null
 let isReady = false
 
+if (!setting.get('app.enable_hardware_acceleration')) {
+    app.disableHardwareAcceleration()
+}
+
 function newWindow(path) {
     let window = new BrowserWindow({
         icon: process.platform === 'linux' ? join(__dirname, '..', 'logo.png') : null,

--- a/src/setting.js
+++ b/src/setting.js
@@ -29,6 +29,7 @@ let defaults = {
     'app.startup_check_updates': true,
     'app.startup_check_updates_delay': 3000,
     'app.loadgame_delay': 100,
+    'app.enable_hardware_acceleration': true,
     'app.hide_busy_delay': 200,
     'app.zoom_factor': 1,
     'autoplay.sec_per_move': 1,


### PR DESCRIPTION
**Goal:**

To let users turn hardware acceleration on/off. By default, it's turned on, but turning it off may help people with slower PCs, and it also lets capturing software (e.g. OBS) to capture the Sabaki window.

**Description:**

This PR adds an `app.enable_hardware_acceleration` key to the `setting`, which controls whether the app will be launched with hardware acceleration enabled. To control this setting, a checkbox was added to the PreferencesDrawer. The default state is left unchanged.