### PR TITLE
get ponder variations from leelasabaki

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2047,6 +2047,20 @@ class App extends Component {
             }
         }
 
+        // Set labels A,B,C,... for variations
+        if (sabakiJson.labels != null) {
+            let labels = sabakiJson.labels.split(';')
+            if (labels.length > 0) {
+                let [tree, index] = this.state.treePosition
+                let node = tree.nodes[index]
+                let board = gametree.getBoard(tree, index)
+                labels.forEach(label => {
+                    if ('LB' in node) node['LB'].push(label)
+                        else node['LB'] = [label]
+                });
+            }
+        }
+        
         if (sabakiJson.node != null) {
             let nodeInfo = sgf.parse(`(;${sabakiJson.node})`)[0].nodes[0]
             let [tree, index] = this.state.treePosition
@@ -2114,13 +2128,6 @@ class App extends Component {
         let [playerIndex, otherIndex] = currentPlayer > 0 ? [0, 1] : [1, 0]
         let playerController = this.attachedEngineControllers[playerIndex]
         let otherController = this.attachedEngineControllers[otherIndex]
-
-        //update move variations for just players move
-        //does not take into account double pass so possibly buggy - dirty hack
-        if (this.state.engineCommands[playerIndex].includes('sabaki-genmovelog')) {
-            // Send Sabaki specific GTP command
-            await playerController.sendCommand({name: 'sabaki-genmovelog'})
-        }
         
         if (playerController == null) {
             if (otherController != null) {
@@ -2139,7 +2146,14 @@ class App extends Component {
         }
 
         this.setBusy(true)
-
+        
+        // Update move variations for the 'play' move
+        // Do this right before genmove to avoid breaking Controller switching
+        if (this.state.engineCommands[playerIndex].includes('sabaki-genmovelog')) {
+            // Send Sabaki specific GTP command
+            await playerController.sendCommand({name: 'sabaki-genmovelog'})
+        }
+        
         let response = await playerController.sendCommand({name: 'genmove', args: [color]})
         let sign = color === 'B' ? 1 : -1
         let pass = true

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2115,6 +2115,13 @@ class App extends Component {
         let playerController = this.attachedEngineControllers[playerIndex]
         let otherController = this.attachedEngineControllers[otherIndex]
 
+        //update move variations for just players move
+        //does not take into account double pass so possibly buggy - dirty hack
+        if (this.state.engineCommands[playerIndex].includes('sabaki-genmovelog')) {
+            // Send Sabaki specific GTP command
+            await playerController.sendCommand({name: 'sabaki-genmovelog'})
+        }
+        
         if (playerController == null) {
             if (otherController != null) {
                 // Switch engines, so the attached engine can play

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -234,7 +234,11 @@ class App extends Component {
             evt.returnValue = ' '
 
             setTimeout(() => {
-                if (this.askForSave()) {
+                if (!setting.get('file.show_ask_for_save_at exit')) {
+                    this.detachEngines()
+                    this.closeWindow = true
+                    this.window.close()
+                } else if (this.askForSave()) {
                     this.detachEngines()
                     this.closeWindow = true
                     this.window.close()

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -97,6 +97,10 @@ class GeneralTab extends Component {
                     text: 'Offer to reload file if changed externally'
                 }),
                 h(PreferencesItem, {
+                    id: 'file.show_ask_for_save_at exit',
+                    text: 'Show save file warning at exit'
+                }),
+                h(PreferencesItem, {
                     id: 'gtp.start_game_after_attach',
                     text: 'Start game right after attaching engines'
                 }),

--- a/src/setting.js
+++ b/src/setting.js
@@ -62,6 +62,7 @@ let defaults = {
     'edit.undo_delay': 100,
     'engines.list': [],
     'file.show_reload_warning': true,
+    'file.show_ask_for_save_at exit': true,
     'find.delay': 100,
     'game.default_board_size': 19,
     'game.default_komi': 6.5,


### PR DESCRIPTION
At the moment Sabaki only shows the variations for Leela.

This will allow ponder variations to update the gametree.

Also:
Add labels A,B,C, ... in the root gametree for variations if specified in leelaSabaki
Add option to exit without asking to save. I personally find that really annoying :)

Needs the commits in my branch of LeelaSabaki to work.