### PR TITLE
Make things more robust when size > 26

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -466,7 +466,7 @@ class App extends Component {
 
         let {extname} = require('path')
         let extension = extname(filename).slice(1)
-        
+
         let gameTrees = []
         let success = true
         let lastProgress = -1
@@ -1596,7 +1596,9 @@ class App extends Component {
             }
         }
 
-        this.setGameInfo(root, {size: [info.size[1], info.size[0]]})
+        if (info.size[1] !== info.size[0]) {
+            this.setGameInfo(root, {size: [info.size[1], info.size[0]]})
+        }
     }
 
     copyVariation(tree, index) {

--- a/src/modules/rotation.js
+++ b/src/modules/rotation.js
@@ -7,14 +7,33 @@ const arrowish = ['AR', 'LN']
 const alpha = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 const alphaRev = [...alpha].reverse()
 
+// Special functions that return the "min" and "max"
+// for the SGF coordinate system...
+//
+// a-z : 1-26
+// A-Z : 27-52
+//
+// Note that lowercase has higher ASCII value,
+// but is considered lower in the SGF system.
+
 function min(one, two) {
+
+	// In case exactly one is lowercase, return it...
+
+	if (one >= 'a' && two <= 'Z') return one
+	if (one <= 'Z' && two >= 'a') return two
+
+	// Same case...
+
 	if (one < two) return one
 	return two
 }
 
 function max(one, two) {
-	if (one > two) return one
-	return two
+	if (one >= 'a' && two <= 'Z') return two
+	if (one <= 'Z' && two >= 'a') return one
+	if (one < two) return two
+	return one
 }
 
 exports.rotatePoint = function(point, width, height, anticlockwise) {


### PR DESCRIPTION
(For the rotation functions.)

When boardsize is > 26, we can't simply use ASCII values for min() and max() because SGF uses lowercase values to mean lower numbers, but ASCII has them as higher numbers.