### PR TITLE
Add option to dump treePosition for #412

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -2289,6 +2289,10 @@ class App extends Component {
 
         state = Object.assign(state, this.inferredState)
 
+        if (setting.get('app.dump_state')) {
+            ipcRenderer.send('dump-state', {treePosition: sabaki.state.treePosition})
+        }
+
         return h('section',
             {
                 class: classNames({

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -134,6 +134,10 @@ class GeneralTab extends Component {
                 h(PreferencesItem, {
                     id: 'app.always_show_result',
                     text: 'Always show game result'
+                }),
+                h(PreferencesItem, {
+                    id: 'app.dump_state',
+                    text: 'Dump state for external tools'
                 })
             ),
 

--- a/src/main.js
+++ b/src/main.js
@@ -148,9 +148,14 @@ function checkForUpdates(showFailDialogs) {
     })
 }
 
+function dumpState(state) {
+    console.log('sabaki_dump_state: ' + JSON.stringify(state))
+}
+
 ipcMain.on('new-window', (evt, ...args) => newWindow(...args))
 ipcMain.on('build-menu', (evt, ...args) => buildMenu(...args))
 ipcMain.on('check-for-updates', (evt, ...args) => checkForUpdates(...args))
+ipcMain.on('dump-state', (evt, ...args) => dumpState(...args))
 
 app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') {


### PR DESCRIPTION
This patch adds an option to dump treePosition to STDOUT for external tools.

ref. #412
