### PR TITLE
Correct "Respository" misspelling

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -526,7 +526,7 @@ let data = [
             },
             {type: 'separator'},
             {
-                label: 'GitHub &Respository',
+                label: 'GitHub &Repository',
                 click: () => shell.openExternal(`https://github.com/SabakiHQ/${sabaki.appName}`)
             },
             {


### PR DESCRIPTION
Trivial thing, but it was bugging me.