### PR TITLE
Add a snap for Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "copyright": "Copyright © 2015-2018 Yichuan Shen",
     "compression": "normal",
     "linux": {
-      "target": "AppImage",
+      "target": [
+        "snap",
+        "AppImage"
+      ],
       "category": "Game"
     },
     "mac": {


### PR DESCRIPTION
I built and tested a snap package of Sabaki, and it works without issue on Ubuntu 16.04. If you're willing to publish this, it can be featured to Linux users installing apps from the Snap Store. You just need to [create an account](https://snapcraft.io/snaps) and then [register the Sabaki name](https://snapcraft.io/register-snap).

The .snap created by `npx build -l snap` can then be released to the Snap Store with `snap push --release stable *.snap`. You'll want to first install snapcraft (`brew install snapcraft`, `snap install snapcraft`, or `apt install snapcraft`) and login (`snapcraft login`).