### PR TITLE
Add an option to change the Game Tree animation delay

### DIFF
--- a/src/components/GameGraph.js
+++ b/src/components/GameGraph.js
@@ -210,6 +210,9 @@ class GameGraph extends Component {
         if (showGameGraph !== this.props.showGameGraph) {
             setTimeout(() => this.updateCameraPosition(), 200)
         }
+
+        // In case it was changed externally
+        delay = setting.get('graph.delay')
     }
 
     getMatrixDict(tree) {

--- a/src/components/GameGraph.js
+++ b/src/components/GameGraph.js
@@ -6,7 +6,9 @@ const gametree = require('../modules/gametree')
 const helper = require('../modules/helper')
 const setting = remote.require('./setting')
 
-let delay = setting.get('graph.delay')
+const getDelay = () => setting.get('graph.delay') * Number(setting.get('graph.animation'))
+
+let delay = getDelay();
 let commentProperties = setting.get('sgf.comment_properties')
 
 class GameGraphNode extends Component {
@@ -212,7 +214,7 @@ class GameGraph extends Component {
         }
 
         // In case it was changed externally
-        delay = setting.get('graph.delay')
+        delay = getDelay()
     }
 
     getMatrixDict(tree) {

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -164,6 +164,22 @@ class GeneralTab extends Component {
                         selected: graphGridSize > 22
                     }, 'Big')
                 )
+            )),
+
+            h('p', {}, h('label', {},
+                'Game Tree Animation Delay: ',
+
+                h('select', {onChange: (evt) => setting.set('graph.delay', Number(evt.currentTarget.value))},
+                    h('option', {
+                        value: 0,
+                        selected: setting.get('graph.delay') === 0
+                    }, 'None'),
+
+                    h('option', {
+                        value: 200,
+                        selected: setting.get('graph.delay') === 200
+                    }, 'Default')
+                )
             ))
         )
     }

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -107,6 +107,10 @@ class GeneralTab extends Component {
                 h(PreferencesItem, {
                     id: 'gtp.auto_genmove',
                     text: 'Automatically generate engine moves'
+                }),
+                h(PreferencesItem, {
+                    id: 'graph.animation',
+                    text: 'Enable game tree animation'
                 })
             ),
 
@@ -163,22 +167,6 @@ class GeneralTab extends Component {
                         value: 'big',
                         selected: graphGridSize > 22
                     }, 'Big')
-                )
-            )),
-
-            h('p', {}, h('label', {},
-                'Game Tree Animation Delay: ',
-
-                h('select', {onChange: (evt) => setting.set('graph.delay', Number(evt.currentTarget.value))},
-                    h('option', {
-                        value: 0,
-                        selected: setting.get('graph.delay') === 0
-                    }, 'None'),
-
-                    h('option', {
-                        value: 200,
-                        selected: setting.get('graph.delay') === 200
-                    }, 'Default')
                 )
             ))
         )

--- a/src/setting.js
+++ b/src/setting.js
@@ -73,6 +73,7 @@ let defaults = {
     'game.show_suicide_warning': true,
     'gamechooser.show_delay': 100,
     'gamechooser.thumbnail_size': 153,
+    'graph.animation': true,
     'graph.delay': 200,
     'graph.grid_size': 22,
     'graph.node_size': 4,


### PR DESCRIPTION
Resolve #491

## Issues

The `delay` variable in `src/components/GameGraph.js` was stored on file initialization and it was not accounting for the ability to be changed externally, despite the actual setting being present in the `settings`.

## Resolution

Explicitly update the `delay` variable on `componentDidUpdate`