### PR TITLE
Resizable Winrate Graph

### DIFF
--- a/src/setting.js
+++ b/src/setting.js
@@ -117,6 +117,7 @@ let defaults = {
     'view.sidebar_width': 200,
     'view.sidebar_minwidth': 100,
     'view.winrategraph_height': 60,
+    'view.winrategraph_minheight': 25,
     'infooverlay.duration': 2000,
     'window.height': 604,
     'window.minheight': 440,

--- a/style/index.css
+++ b/style/index.css
@@ -474,6 +474,15 @@ header, #bar .bar {
         overflow: hidden;
         z-index: 3;
     }
+    #winrategraph .horizontalresizer {
+        position: absolute;
+        bottom: 0px;
+        left: 0;
+        right: 0;
+        height: 5px;
+        cursor: ns-resize;
+        z-index: 10;
+    }
     #winrategraph svg {
         position: absolute;
         top: 0;


### PR DESCRIPTION
Lets you resize the winrate graph like you can resize the move comment sidebar.

I have been zooming in/out too much to see more detail on the graph, so I made it resizable.

I ended up putting all the relevant code in the WinrateGraph.js rather than Sidebar.js, otherwise, it turned out the same component would end up having conflicting/confusing mouse event handling. Added a min. width in the settings.json, and it has a hard-coded 500 px max (should be plenty).