### PR TITLE
Resize gameboard when toggling show sidebars

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -313,6 +313,7 @@ class App extends Component {
             if (!this.window.isMaximized() && !this.window.isMinimized() && !this.window.isFullScreen()) {
                 this.window.setContentSize(width + widthDiff, height)
             }
+            window.dispatchEvent(new Event('resize'))
         }
 
         // Handle zoom factor


### PR DESCRIPTION
When toggling right or left sidebars, the board doesn't get resized & redrawn to fit the window.
This fixes that.