### PR TITLE
Fix for menu checkbox state

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -331,6 +331,8 @@ class App extends Component {
             'view.show_move_colorization': 'showMoveColorization',
             'view.show_next_moves': 'showNextMoves',
             'view.show_siblings': 'showSiblings',
+            'view.show_graph': 'showGameGraph',
+            'view.show_comments': 'showCommentBox',
             'view.fuzzy_stone_placement': 'fuzzyStonePlacement',
             'view.animated_stone_placement': 'animateStonePlacement',
             'graph.grid_size': 'graphGridSize',


### PR DESCRIPTION
When you clicked on either "View-> Show Game Tree" or "View-> Show Comments" the checkboxes weren't updating immediately.

This is fixed in this patch, which adds the missing state tracking code.
