### PR TITLE
Animated analysis variations - continuous updating

### DIFF
--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -150,20 +150,17 @@ class Goban extends Component {
                         let vertex = variation[0];
                         if (vertex == null) return
                         let analysisline = this.props.analysis.find(x => helper.vertexEquals(x.vertex, vertex)) || {}
-                        if (analysisline == null)
-                            return
+                        if (analysisline == null) return
                         let nextvariation = analysisline["variation"]
                         let nextsign = analysisline["sign"]
                         if (nextvariation == null) return
                         if (nextsign != sign) return
 
                         if (variation.length == nextvariation.length) return
-                        //if (variation != nextvariation.slice(0,variation.length)) {
                         if (!helper.equals(variation,nextvariation.slice(0,variation.length))) {
                             return
-                        } else {
-                            variation = nextvariation
                         }
+                        variation = nextvariation
                     }
                 }
                 this.setState(({variationIndex = -1}) => ({

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -145,6 +145,27 @@ class Goban extends Component {
             clearInterval(this.variationIntervalId)
 
             this.variationIntervalId = setInterval(() => {
+                if (this.state.variationIndex) {
+                    if (this.state.variationIndex >= variation.length) {
+                        let vertex = variation[0];
+                        if (vertex == null) return
+                        let analysisline = this.props.analysis.find(x => helper.vertexEquals(x.vertex, vertex)) || {}
+                        if (analysisline == null)
+                            return
+                        let nextvariation = analysisline["variation"]
+                        let nextsign = analysisline["sign"]
+                        if (nextvariation == null) return
+                        if (nextsign != sign) return
+
+                        if (variation.length == nextvariation.length) return
+                        //if (variation != nextvariation.slice(0,variation.length)) {
+                        if (!helper.equals(variation,nextvariation.slice(0,variation.length))) {
+                            return
+                        } else {
+                            variation = nextvariation
+                        }
+                    }
+                }
                 this.setState(({variationIndex = -1}) => ({
                     variation,
                     variationSign: sign,


### PR DESCRIPTION
For only animate the variation mode: extends the animation of the current analyzed variation when more (deeper) moves arrive for the same variation (like a ladder) -- a different variation for the same root move won't be updated, only for the same variation already displayed.

Cons: Might be of limited use since its not very likely the current variation is always continued for every single move... so I created it separately from the other pull request for your opinions on whether its worthwhile.