### PR TITLE
Continuous updates for analysis variations in instant replay

### DIFF
--- a/src/setting.js
+++ b/src/setting.js
@@ -41,6 +41,7 @@ let defaults = {
     'autoscroll.min_interval': 50,
     'board.analysis_interval': 100,
     'board.variation_instant_replay': false,
+    'board.variation_instant_replay_update_continuously': true,
     'board.variation_replay_interval': 500,
     'cleanmarkup.annotations': false,
     'cleanmarkup.arrow': true,


### PR DESCRIPTION
For instant replay mode only: continuously display the last variation for the move, changing it at most every replay_interval.  It is a setting right now as default true: "board.variation_instant_replay_update_continuously"

Also, added keyboard shortcut of Ctrl+Space (or Meta+Space) that has the following functionality:

When the setting board.variation_instant_replay_update_continuously == true .... When viewing the variation you can pause/unpause continuous updates for the variation using the keyboard shortcut. When you move the mouse off the variation (stopping it) and go back to the same or a different variation the continuous updates are reset and will display.

When the setting board.variation_instant_replay_update_continuously == false, the keyboard shortcut does nothing, and reverts back to the behaviour before the patch.

This gives you time time to study variations: if you find one interesting enough to ponder it for a while you can hit ctrl-space to pause before the next variation comes, and when you are done pondering you can hit ctrl-space to see if there is a new variation for the move, without needing to move the mouse off and back on again.