### PR TITLE
Winrate graph invert option

### DIFF
--- a/src/components/WinrateGraph.js
+++ b/src/components/WinrateGraph.js
@@ -66,6 +66,13 @@ class WinrateGraph extends Component {
     }
 
     render({width, currentIndex, data}) {
+
+        let inv = setting.get('view.winrategraph_invert')
+
+        if (inv) {
+            data = data.map(x => x == null ? null : 100 - x)
+        }
+
         let dataDiff = data.map((x, i) => i === 0 || x == null || data[i - 1] == null ? null : x - data[i - 1])
         let dataDiffMax = Math.max(...dataDiff.map(Math.abs), 25)
 
@@ -95,7 +102,7 @@ class WinrateGraph extends Component {
                 // Draw background
 
                 h('defs', {},
-                    h('linearGradient', {id: 'bgGradient', x1: 0, y1: 0, x2: 0, y2: 1},
+                    h('linearGradient', {id: 'bgGradient', x1: 0, y1: inv ? 1 : 0, x2: 0, y2: inv ? 0 : 1},
                         h('stop', {
                             offset: '0%',
                             'stop-color': 'white',
@@ -120,9 +127,9 @@ class WinrateGraph extends Component {
 
                                 if (instructions.length === 0) return ''
 
-                                return `M ${instructions[0][0]},100 `
+                                return `M ${instructions[0][0]},${inv ? 0 : 100} `
                                     + instructions.map(x => `L ${x.join(',')}`).join(' ')
-                                    + ` L ${instructions.slice(-1)[0][0]},100 Z`
+                                    + ` L ${instructions.slice(-1)[0][0]},${inv ? 0 : 100} Z`
                             })()
                         })
                     )

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -144,7 +144,11 @@ class GeneralTab extends Component {
                 h(PreferencesItem, {
                     id: 'app.always_show_result',
                     text: t('Always show game result')
-                })
+                }),
+                h(PreferencesItem, {
+                    id: 'view.winrategraph_invert',
+                    text: t('Invert winrate graph')
+                }),
             ),
 
             h('p', {}, h('label', {},

--- a/src/setting.js
+++ b/src/setting.js
@@ -135,6 +135,7 @@ let defaults = {
     'view.sidebar_minwidth': 100,
     'view.winrategraph_height': 60,
     'view.winrategraph_minheight': 25,
+    'view.winrategraph_invert': false,
     'infooverlay.duration': 2000,
     'window.height': 604,
     'window.minheight': 440,


### PR DESCRIPTION
I don't know if you'll like this, but this adds an option to invert the winrate graph so that the data line itself tracks Black's winrate, which I think is more intuitive, Black being player 1 and all.

I didn't fully understand the render function so hacked at it as best I could. If you decide to accept it, I'd recommend checking my changes make sense...

Also, there's the minor issue that the change in the preferences won't take effect until the graph is redrawn. In fact, one could argue it doesn't need a preferences item at all, with the `settings.json` item being sufficient.