### PR TITLE
Preserve window maximized state

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "argv-split": "^2.0.1",
     "classnames": "^2.2.6",
     "dolm": "^0.7.3-beta",
+    "electron-store": "^5.1.1",
     "fix-path": "^3.0.0",
     "iconv-lite": "^0.5.1",
     "jschardet": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "argv-split": "^2.0.1",
     "classnames": "^2.2.6",
     "dolm": "^0.7.3-beta",
-    "electron-store": "^5.1.1",
     "fix-path": "^3.0.0",
     "iconv-lite": "^0.5.1",
     "jschardet": "^2.1.1",

--- a/src/main.js
+++ b/src/main.js
@@ -46,11 +46,6 @@ function newWindow(path) {
     setting.set('window.maximized', false)
   })
 
-  window.on('resize', () => {
-    setting.set('window.width', window.getSize()[0])
-    setting.set('window.height', window.getSize()[1])
-  })
-
   window.on('closed', () => {
     window = null
   })

--- a/src/main.js
+++ b/src/main.js
@@ -13,12 +13,6 @@ function newWindow(path) {
       process.platform === 'linux' ? resolve(__dirname, '../logo.png') : null,
     title: app.name,
     useContentSize: true,
-    width: setting.get('window.preWidth')
-      ? setting.get('window.preWidth')
-      : setting.get('window.width'),
-    height: setting.get('window.preHeight')
-      ? setting.get('window.preHeight')
-      : setting.get('window.height'),
     width: setting.get('window.width'),
     height: setting.get('window.height'),
     minWidth: setting.get('window.minwidth'),
@@ -39,22 +33,22 @@ function newWindow(path) {
     window.show()
   })
 
-  if (setting.get('window.max') === true) {
+  if (setting.get('window.maximized') === true) {
     window.maximize()
   }
 
   // store the window size
   window.on('maximize', () => {
-    setting.set('window.max', true)
+    setting.set('window.maximized', true)
   })
 
   window.on('unmaximize', () => {
-    setting.set('window.max', false)
+    setting.set('window.maximized', false)
   })
 
   window.on('resize', () => {
-    setting.set('window.preWidth', window.getSize()[0])
-    setting.set('window.preHeight', window.getSize()[1])
+    setting.set('window.width', window.getSize()[0])
+    setting.set('window.height', window.getSize()[1])
   })
 
   window.on('closed', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -4,14 +4,6 @@ const i18n = require('./i18n')
 const setting = require('./setting')
 const updater = require('./updater')
 
-const Store = require('electron-store')
-const store = new Store()
-
-// get the previous size
-let preWidth = store.get('preWidth')
-let preHeight = store.get('preHeight')
-let maxWindow = store.get('maxWindow')
-
 let windows = []
 let openfile = null
 
@@ -21,8 +13,14 @@ function newWindow(path) {
       process.platform === 'linux' ? resolve(__dirname, '../logo.png') : null,
     title: app.name,
     useContentSize: true,
-    width: preWidth ? preWidth : setting.get('window.width'),
-    height: preHeight ? preHeight : setting.get('window.height'),
+    width: setting.get('window.preWidth')
+      ? setting.get('window.preWidth')
+      : setting.get('window.width'),
+    height: setting.get('window.preHeight')
+      ? setting.get('window.preHeight')
+      : setting.get('window.height'),
+    width: setting.get('window.width'),
+    height: setting.get('window.height'),
     minWidth: setting.get('window.minwidth'),
     minHeight: setting.get('window.minheight'),
     autoHideMenuBar: !setting.get('view.show_menubar'),
@@ -41,22 +39,22 @@ function newWindow(path) {
     window.show()
   })
 
-  if (maxWindow === 'true') {
+  if (setting.get('window.max') === true) {
     window.maximize()
   }
 
   // store the window size
   window.on('maximize', () => {
-    store.set('maxWindow', 'true')
+    setting.set('window.max', true)
   })
+
   window.on('unmaximize', () => {
-    store.set('maxWindow', 'false')
+    setting.set('window.max', false)
   })
+
   window.on('resize', () => {
-    const [nowWidth, nowHeight] = window.getSize()
-    store.set('preWidth', nowWidth)
-    store.set('preHeight', nowHeight)
-    //console.log(`Width: ${preWidth}, Height: ${preHeight}`);
+    setting.set('window.preWidth', window.getSize()[0])
+    setting.set('window.preHeight', window.getSize()[1])
   })
 
   window.on('closed', () => {

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,14 @@ const i18n = require('./i18n')
 const setting = require('./setting')
 const updater = require('./updater')
 
+const Store = require('electron-store')
+const store = new Store()
+
+// get the previous size
+let preWidth = store.get('preWidth')
+let preHeight = store.get('preHeight')
+let maxWindow = store.get('maxWindow')
+
 let windows = []
 let openfile = null
 
@@ -13,8 +21,8 @@ function newWindow(path) {
       process.platform === 'linux' ? resolve(__dirname, '../logo.png') : null,
     title: app.name,
     useContentSize: true,
-    width: setting.get('window.width'),
-    height: setting.get('window.height'),
+    width: preWidth ? preWidth : setting.get('window.width'),
+    height: preHeight ? preHeight : setting.get('window.height'),
     minWidth: setting.get('window.minwidth'),
     minHeight: setting.get('window.minheight'),
     autoHideMenuBar: !setting.get('view.show_menubar'),
@@ -31,6 +39,24 @@ function newWindow(path) {
 
   window.once('ready-to-show', () => {
     window.show()
+  })
+
+  if (maxWindow === 'true') {
+    window.maximize()
+  }
+
+  // store the window size
+  window.on('maximize', () => {
+    store.set('maxWindow', 'true')
+  })
+  window.on('unmaximize', () => {
+    store.set('maxWindow', 'false')
+  })
+  window.on('resize', () => {
+    const [nowWidth, nowHeight] = window.getSize()
+    store.set('preWidth', nowWidth)
+    store.set('preHeight', nowHeight)
+    //console.log(`Width: ${preWidth}, Height: ${preHeight}`);
   })
 
   window.on('closed', () => {

--- a/src/setting.js
+++ b/src/setting.js
@@ -211,9 +211,7 @@ let defaults = {
   'window.minheight': 440,
   'window.minwidth': 526,
   'window.width': 564,
-  'window.max': false,
-  'window.preWidth': undefined,
-  'window.preHeight': undefined
+  'window.maximized': false
 }
 
 let eventEmitters = {}

--- a/src/setting.js
+++ b/src/setting.js
@@ -210,7 +210,10 @@ let defaults = {
   'window.height': 604,
   'window.minheight': 440,
   'window.minwidth': 526,
-  'window.width': 564
+  'window.width': 564,
+  'window.max': false,
+  'window.preWidth': undefined,
+  'window.preHeight': undefined
 }
 
 let eventEmitters = {}


### PR DESCRIPTION
#586 
This breaks package, at least portable will not work.
It needs `node_modules/{electron-store,conf,ajv,debounce-fn,mimic-fn,dot-prop,is-obj,env-paths,json-schema-typed,make-dir,semver,onetime,pkg-up,find-up,locate-path,p-locate,p-limit,path-exists,write-file-atomic,imurmurhash,is-typedarray,signal-exit,typedarray-to-buffer,type-fest,p-try,uri-js,……}/**/*",`
I'm not sure how much the `……` should be.
works: `"!node_modules"` => `"node_modules"`