### PR TITLE
Add default engine for analysis

### DIFF
--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -595,10 +595,27 @@ class EngineItem extends Component {
     super()
 
     this.handleChange = evt => {
-      let {id, name, path, args, commands, onChange = noop} = this.props
+      let {
+        id,
+        name,
+        path,
+        args,
+        commands,
+        analysis,
+        onChange = noop
+      } = this.props
       let element = evt.currentTarget
+      let value = element.type === 'checkbox' ? element.checked : element.value
 
-      onChange({id, name, path, args, commands, [element.name]: element.value})
+      onChange({
+        id,
+        name,
+        path,
+        args,
+        commands,
+        analysis,
+        [element.name]: value
+      })
     }
 
     this.handleBrowseButtonClick = () => {
@@ -608,8 +625,8 @@ class EngineItem extends Component {
       })
       if (!result || result.length === 0) return
 
-      let {id, name, args, commands, onChange = noop} = this.props
-      onChange({id, name, args, commands, path: result[0]})
+      let {id, name, args, commands, analysis, onChange = noop} = this.props
+      onChange({id, name, args, commands, analysis, path: result[0]})
     }
 
     this.handleRemoveButtonClick = () => {
@@ -618,7 +635,7 @@ class EngineItem extends Component {
     }
   }
 
-  render({name, path, args, commands}) {
+  render({name, path, args, commands, analysis}) {
     return h(
       'li',
       {},
@@ -687,6 +704,17 @@ class EngineItem extends Component {
           name: 'commands',
           onChange: this.handleChange
         })
+      ),
+      h(
+        'label',
+        {},
+        h('input', {
+          type: 'checkbox',
+          name: 'analysis',
+          defaultChecked: analysis,
+          onChange: this.handleChange
+        }),
+        t('Use as the default analysis engine')
       )
     )
   }
@@ -696,10 +724,10 @@ class EnginesTab extends Component {
   constructor() {
     super()
 
-    this.handleItemChange = ({id, name, path, args, commands}) => {
+    this.handleItemChange = ({id, name, path, args, commands, analysis}) => {
       let engines = this.props.engines.slice()
 
-      engines[id] = {name, path, args, commands}
+      engines[id] = {name, path, args, commands, analysis}
       setting.set('engines.list', engines)
     }
 
@@ -713,7 +741,10 @@ class EnginesTab extends Component {
     this.handleAddButtonClick = evt => {
       evt.preventDefault()
 
-      let engines = [{name: '', path: '', args: ''}, ...this.props.engines]
+      let engines = [
+        {name: '', path: '', args: '', analysis: false},
+        ...this.props.engines
+      ]
       setting.set('engines.list', engines)
 
       setImmediate(() => {
@@ -749,13 +780,14 @@ class EnginesTab extends Component {
         h(
           'ul',
           {},
-          engines.map(({name, path, args, commands}, id) =>
+          engines.map(({name, path, args, commands, analysis}, id) =>
             h(EngineItem, {
               id,
               name,
               path,
               args,
               commands,
+              analysis,
 
               onChange: this.handleItemChange,
               onRemove: this.handleItemRemove

--- a/src/menu.js
+++ b/src/menu.js
@@ -446,73 +446,42 @@ exports.get = function(props = {}) {
         {
           label: i18n.t('menu.engines', 'Toggle &Analysis'),
           accelerator: 'F4',
-          click: () => {
-            let getAnalysisEngineSyncerId = hasDefaultEngine => {
-              let preferredEngineSyncerId =
-                sabaki.lastAnalyzingEngineSyncerId ||
-                sabaki.state.attachedEngineSyncers
-                  .filter(syncer => syncer.engine.analysis)
-                  .map(syncer => syncer.id)[0]
-              if (preferredEngineSyncerId != null) {
-                return preferredEngineSyncerId
+          click: async () => {
+            if (sabaki.state.analyzingEngineSyncerId == null) {
+              let defaultEngine = setting
+                .get('engines.list')
+                .find(engine => engine.analysis)
+
+              let syncerId = sabaki.getAnalysisEngineSyncerId(
+                defaultEngine != null
+              )
+              if (syncerId != null) {
+                await sabaki.startAnalysis(syncerId)
+                return
               }
 
-              if (hasDefaultEngine) {
-                return null
-              }
-
-              return sabaki.state.attachedEngineSyncers
-                .filter(syncer =>
-                  syncer.commands.some(x =>
-                    setting.get('engines.analyze_commands').includes(x)
-                  )
-                )
-                .map(syncer => syncer.id)[0]
-            }
-
-            let defaultEngine = setting
-              .get('engines.list')
-              .find(engine => engine.analysis)
-            let syncerId = getAnalysisEngineSyncerId(defaultEngine != null)
-
-            if (syncerId == null) {
-              if (defaultEngine != null) {
-                if (!sabaki.state.busy) {
-                  sabaki.setBusy(true)
-
-                  let [defaultEngineSyncer] = sabaki.attachEngines(
-                    [defaultEngine],
-                    {autoStart: false}
-                  )
-
-                  defaultEngineSyncer.on('initialized', ({error}) => {
-                    if (error != null) {
-                      dialog.showMessageBox(
-                        i18n.t(
-                          'menu.engines',
-                          'The analysis engine initialization failed.'
-                        ),
-                        'error'
-                      )
-                    } else {
-                      sabaki.startAnalysis(defaultEngineSyncer.id)
-                    }
-                    sabaki.setBusy(false)
-                  })
-
-                  defaultEngineSyncer.controller.start()
-                }
-              } else {
+              if (defaultEngine == null) {
                 dialog.showMessageBox(
                   i18n.t('menu.engines', 'No engine available for analysis.'),
                   'info'
                 )
+                return
               }
-              return
-            }
 
-            if (sabaki.state.analyzingEngineSyncerId == null) {
-              sabaki.startAnalysis(syncerId)
+              try {
+                sabaki.setBusy(true)
+                await sabaki.attachAndStartAnalysis(defaultEngine)
+              } catch {
+                dialog.showMessageBox(
+                  i18n.t(
+                    'menu.engines',
+                    'Initialization of the analysis engine failed.'
+                  ),
+                  'error'
+                )
+              } finally {
+                sabaki.setBusy(false)
+              }
             } else {
               sabaki.stopAnalysis()
             }

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -116,8 +116,8 @@ export default class EngineSyncer extends EventEmitter {
               )
           : [])
       ])
-        .then(() => this.controller.emit('initialized', {}))
-        .catch(error => this.controller.emit('initialized', {error}))
+        .then(() => this.emit('initialized', {}))
+        .catch(error => this.emit('initialized', {error}))
     })
 
     this.controller.on('stopped', () => {
@@ -177,7 +177,6 @@ export default class EngineSyncer extends EventEmitter {
 
     for (let eventName of [
       'started',
-      'initialized',
       'stopped',
       'command-sent',
       'response-received'

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -115,7 +115,9 @@ export default class EngineSyncer extends EventEmitter {
                 this.controller.sendCommand(Command.fromString(command))
               )
           : [])
-      ]).catch(noop)
+      ])
+        .then(() => this.controller.emit('initialized', {}))
+        .catch(error => this.controller.emit('initialized', {error}))
     })
 
     this.controller.on('stopped', () => {
@@ -175,6 +177,7 @@ export default class EngineSyncer extends EventEmitter {
 
     for (let eventName of [
       'started',
+      'initialized',
       'stopped',
       'command-sent',
       'response-received'

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1658,7 +1658,7 @@ class Sabaki extends EventEmitter {
     })
   }
 
-  attachEngines(engines) {
+  attachEngines(engines, onInitialized = helper.noop) {
     let attaching = []
     let getEngineName = name => {
       let counter = 1
@@ -1761,6 +1761,16 @@ class Sabaki extends EventEmitter {
           message: 'Engine Started',
           engine: engine.name
         })
+      })
+
+      syncer.controller.on('initialized', evt => {
+        gtplogger.write({
+          type: 'meta',
+          message: 'Engine Initialized',
+          engine: engine.name
+        })
+
+        onInitialized({syncer, ...evt})
       })
 
       syncer.controller.on('stopped', () => {

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1658,7 +1658,7 @@ class Sabaki extends EventEmitter {
     })
   }
 
-  attachEngines(engines, onInitialized = helper.noop) {
+  attachEngines(engines, {autoStart = true} = {}) {
     let attaching = []
     let getEngineName = name => {
       let counter = 1
@@ -1779,7 +1779,9 @@ class Sabaki extends EventEmitter {
         })
       })
 
-      syncer.controller.start()
+      if (autoStart) {
+        syncer.controller.start()
+      }
 
       attaching.push(syncer)
     }

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1680,6 +1680,14 @@ class Sabaki extends EventEmitter {
 
       let syncer = new EngineSyncer(engine)
 
+      syncer.on('initialized', () => {
+        gtplogger.write({
+          type: 'meta',
+          message: 'Engine Initialized',
+          engine: engine.name
+        })
+      })
+
       syncer.on('analysis-update', () => {
         if (this.state.analyzingEngineSyncerId === syncer.id) {
           // Update analysis info
@@ -1761,16 +1769,6 @@ class Sabaki extends EventEmitter {
           message: 'Engine Started',
           engine: engine.name
         })
-      })
-
-      syncer.controller.on('initialized', evt => {
-        gtplogger.write({
-          type: 'meta',
-          message: 'Engine Initialized',
-          engine: engine.name
-        })
-
-        onInitialized({syncer, ...evt})
       })
 
       syncer.controller.on('stopped', () => {

--- a/style/index.css
+++ b/style/index.css
@@ -1243,6 +1243,18 @@ header {
   }
   .engines-list li a.browse:active {
     opacity: 1;
+  }
+  .engines-list input[type="checkbox"] {
+    -webkit-appearance: checkbox;
+    -moz-appearance: checkbox;
+    -ms-appearance: checkbox;
+    width: 1.5em;
+    margin-right: 4px;
+    vertical-align: -3px;
+    font-size: 0.8em;
+  }
+  .engines-list input[type="checkbox"]::before {
+    background: none;
 }
 
 .properties-list table {


### PR DESCRIPTION
This enables to set the default engine for the analysis and start analysis without opening 'Engine Sidebar'. To achieve this, I added a new event called 'initialized' to EngineSyncer.
#664 

Note: the default engine is selected by checkbox instead of radiobutton, so the analysis starts with the top engine that is checked as the default engine. This allows you to avoid selecting a default engine and simplifies the code when adding or removing engines.