### PR TITLE
Change working directory to portable path.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,6 +22,8 @@ import * as gametree from '../modules/gametree.js'
 import * as gtplogger from '../modules/gtplogger.js'
 import * as helper from '../modules/helper.js'
 
+const process = require('process')
+
 const setting = remote.require('./setting')
 const t = i18n.context('App')
 
@@ -29,6 +31,11 @@ const leftSidebarMinWidth = setting.get('view.sidebar_minwidth')
 const sidebarMinWidth = setting.get('view.leftsidebar_minwidth')
 
 fixPath()
+
+const portableDir = process.env.PORTABLE_EXECUTABLE_DIR
+if (portableDir) {
+  process.chdir(portableDir)
+}
 
 class App extends Component {
   constructor(props) {


### PR DESCRIPTION
Do not support sub-folder engine path:
```
events.js:187 Uncaught Error: spawn ./0/Leela0110GTP_OpenCL.exe ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:264)
    at onErrorNT (internal/child_process.js:456)
    at processTicksAndRejections (internal/process/task_queues.js:80)
errnoException @ internal/errors.js:474
ChildProcess._handle.onexit @ internal/child_process.js:264
onErrorNT @ internal/child_process.js:456
processTicksAndRejections @ internal/process/task_queues.js:80
```