### PR TITLE
Detach all engines when the window closed

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -181,16 +181,15 @@ class App extends Component {
 
       evt.returnValue = ' '
 
-      setTimeout(async () => {
+      setTimeout(() => {
         if (sabaki.askForSave()) {
-          let promise = sabaki.detachEngines(
+          sabaki.detachEngines(
             this.state.attachedEngineSyncers.map(syncer => syncer.id)
           )
 
           gtplogger.close()
           this.closeWindow = true
           sabaki.window.close()
-          await promise
         }
       })
     })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -181,11 +181,16 @@ class App extends Component {
 
       evt.returnValue = ' '
 
-      setTimeout(() => {
+      setTimeout(async () => {
         if (sabaki.askForSave()) {
+          let promise = sabaki.detachEngines(
+            this.state.attachedEngineSyncers.map(syncer => syncer.id)
+          )
+
           gtplogger.close()
           this.closeWindow = true
           sabaki.window.close()
+          await promise
         }
       })
     })


### PR DESCRIPTION
Running the engine over SSH may leave the engine's processes on the remote computer. This PR prevents it.
Also, if await sabaki.detachEngines() is done before sabaki.window.close(), it may take a long time to close the window, so await is at the end.