### PR TITLE
Added accelerator for board.show_analysis to show/hide analysis results handly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
   (thanks to @ebifrier, #711)
 - Failed to load external links in comments (thanks to @baldor-f, #754)
 
+**Changed**
+
+- <kbd>Ctrl+H</kbd> toggles the visibility of the analysis heatmap, and
+  <kbd>Ctrl+Shift+H</kbd> cycles through the different types of heatmap labels
+  (#752)
+
 ## [Sabaki v0.51.1][v0.51.1] (2020-04-12)
 
 **Added**

--- a/src/menu.js
+++ b/src/menu.js
@@ -634,6 +634,7 @@ exports.get = function(props = {}) {
               label: i18n.t('menu.view', '&Don’t Show'),
               type: 'checkbox',
               checked: !showAnalysis,
+              accelerator: '`',
               click: () => toggleSetting('board.show_analysis')
             },
             {type: 'separator'},

--- a/src/menu.js
+++ b/src/menu.js
@@ -634,7 +634,7 @@ exports.get = function(props = {}) {
               label: i18n.t('menu.view', '&Don’t Show'),
               type: 'checkbox',
               checked: !showAnalysis,
-              accelerator: '`',
+              accelerator: 'CmdOrCtrl+H',
               click: () => toggleSetting('board.show_analysis')
             },
             {type: 'separator'},
@@ -642,18 +642,30 @@ exports.get = function(props = {}) {
               label: i18n.t('menu.view', 'Show &Win Rate'),
               type: 'checkbox',
               checked: !!showAnalysis && analysisType === 'winrate',
+              accelerator: 'CmdOrCtrl+Shift+H',
               click: () => {
                 setting.set('board.show_analysis', true)
-                setting.set('board.analysis_type', 'winrate')
+                setting.set(
+                  'board.analysis_type',
+                  setting.get('board.analysis_type') === 'winrate'
+                    ? 'scoreLead'
+                    : 'winrate'
+                )
               }
             },
             {
               label: i18n.t('menu.view', 'Show &Score Lead'),
               type: 'checkbox',
               checked: !!showAnalysis && analysisType === 'scoreLead',
+              accelerator: 'CmdOrCtrl+Shift+H',
               click: () => {
                 setting.set('board.show_analysis', true)
-                setting.set('board.analysis_type', 'scoreLead')
+                setting.set(
+                  'board.analysis_type',
+                  setting.get('board.analysis_type') === 'scoreLead'
+                    ? 'winrate'
+                    : 'scoreLead'
+                )
               }
             }
           ]


### PR DESCRIPTION
Go learners can use analyzer as question & answer training. So switching analysis results shown/hidden is often to use.

I chose back quote (`) as the short key, that's can be discussed.