### PR TITLE
A shortcut for game move by best point from analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Sabaki develop](2020-10-31)
+
+**Added**
+
+- A shortcut for game move by best point from analysis.
+
 ## [Sabaki v0.51.1][v0.51.1] (2020-04-12)
 
 **Added**

--- a/src/menu.js
+++ b/src/menu.js
@@ -150,6 +150,12 @@ exports.get = function(props = {}) {
         },
         {type: 'separator'},
         {
+          label: i18n.t('menu.play', 'Move by Analysis'),
+          accelerator: 'Space',
+          click: () => sabaki.moveByAnalysis()
+        },
+        {type: 'separator'},
+        {
           label: i18n.t('menu.play', '&Estimate'),
           accelerator: 'CmdOrCtrl+Shift+E',
           click: () =>

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -2885,6 +2885,18 @@ class Sabaki extends EventEmitter {
       y
     )
   }
+
+  moveByAnalysis() {
+    if (this.state.analysis) {
+      const best = this.state.analysis.variations.reduce(
+        (best, variation) =>
+          !best || variation.winrate > best.winrate ? variation : best,
+        null
+      )
+
+      if (best) this.clickVertex(best.vertex)
+    }
+  }
 }
 
 export default new Sabaki()


### PR DESCRIPTION
I tried to use analyzer & AI player simultaneously, that's buggy when I back off and re-move frequently. So use an analyzer as an AI player is more practicable at present. And you can also control the pondering time flexibly.

I chose *Space* key as the shortcut for *move-by-analysis*, that's can be discussed.