### PR TITLE
Link class was incorrect. Correcting issue #748

### DIFF
--- a/src/components/MarkdownContentDisplay.js
+++ b/src/components/MarkdownContentDisplay.js
@@ -46,7 +46,7 @@ function Link({href, title, children}) {
   return h(
     ContentDisplay,
     {},
-    h('a', {class: 'external', href, title}, typographer(children))
+    h('a', {class: 'comment-external', href, title}, typographer(children))
   )
 }
 


### PR DESCRIPTION
Link class was external, and the contentDisplay checked for "comment-external" class to open the link outside the window