### PR TITLE
Fix crash on “View Comments” (#719)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -257,7 +257,7 @@ class App extends Component {
         !sabaki.window.isMinimized() &&
         !sabaki.window.isFullScreen()
       ) {
-        sabaki.window.setContentSize(width + widthDiff, height)
+        sabaki.window.setContentSize(Math.floor(width + widthDiff), height)
       }
 
       window.dispatchEvent(new Event('resize'))


### PR DESCRIPTION
I also had issue #719 on my Windows 10 PC. `window.setContentSize` expects integer arguments but `widthDiff` is not (always) a whole number. I have verified that this fix works by building and running Sabaki on my PC.

I love Sabaki! Thanks a lot for all your hard work!