### PR TITLE
Fix layout of edit mode when comment box is hidden

### DIFF
--- a/src/components/sidebars/CommentBox.js
+++ b/src/components/sidebars/CommentBox.js
@@ -280,8 +280,8 @@ export default class CommentBox extends Component {
     }
   }
 
-  shouldComponentUpdate({showCommentBox}) {
-    return showCommentBox && !this.dirty
+  shouldComponentUpdate() {
+    return !this.dirty
   }
 
   componentWillReceiveProps({treePosition, mode, title, comment}) {
@@ -316,6 +316,7 @@ export default class CommentBox extends Component {
       treePosition,
       moveAnnotation,
       positionAnnotation,
+      showCommentBox,
 
       onLinkClick = noop
     },
@@ -325,7 +326,8 @@ export default class CommentBox extends Component {
       'section',
       {
         ref: el => (this.element = el),
-        id: 'properties'
+        id: 'properties',
+        class: showCommentBox ? 'commentBoxShown' : ''
       },
 
       h(

--- a/style/index.css
+++ b/style/index.css
@@ -629,8 +629,8 @@ header {
     color: #222;
     overflow: hidden;
   }
-  .edit #properties .edit,
-  .edit #properties .edit textarea {
+  .edit #properties.commentBoxShown .edit,
+  .edit #properties.commentBoxShown .edit textarea {
     display: block;
     color: #222;
   }


### PR DESCRIPTION
When the comment box is hidden and edit mode is being turned on, the layout and therefore the mouse event handling on the game graph gets messed up (offset by some amount).

I fixed that.

Be aware that I am not very experienced with react, so I don't know if this is the best way of doing this.

Cheers