### PR TITLE
Upgrade to latest Electron, thus adding M1 Mac Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: npm install, build, and test
       run: |
         npm install

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13.x

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "devDependencies": {
     "concurrently": "^5.1.0",
-    "electron": "^9.4.4",
+    "electron": "^10.4.7",
     "electron-builder": "^22.4.1",
     "esm": "^3.2.25",
     "mocha": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "devDependencies": {
     "concurrently": "^5.1.0",
-    "electron": "^10.4.7",
+    "electron": "^11.4.8",
     "electron-builder": "^22.4.1",
     "esm": "^3.2.25",
     "mocha": "^7.1.1",
@@ -128,7 +128,7 @@
     "format": "npm run format-base -- --write",
     "watch-format": "onchange \"**/*.{js,html,md}\" \"!{{dist,i18n}/**,bundle.js*}\" -- prettier --write {{changed}}",
     "watch": "concurrently \"webpack --mode development --watch\" \"npm run watch-format\"",
-    "dist:macos": "npm run bundle && electron-builder -m --x64",
+    "dist:macos": "npm run bundle && electron-builder -m --x64 --arm64",
     "dist:linux": "npm run bundle && electron-builder -l --ia32 --x64 && node ./ci/mv.js ./dist/sabaki-vx.x.x-linux-i386.AppImage ./dist/sabaki-vx.x.x-linux-ia32.AppImage && node ./ci/mv.js ./dist/sabaki-vx.x.x-linux-x86_64.AppImage ./dist/sabaki-vx.x.x-linux-x64.AppImage",
     "dist:arm64": "npm run bundle && electron-builder -l --arm64",
     "dist:win32": "npm run bundle && electron-builder -w --ia32 && node ./ci/mv.js ./dist/sabaki-vx.x.x-win.exe ./dist/sabaki-vx.x.x-win-ia32-setup.exe",

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
   },
   "devDependencies": {
     "concurrently": "^5.1.0",
-    "electron": "^11.4.8",
-    "electron-builder": "^22.4.1",
+    "electron": "^12.0.0",
+    "electron-builder": "^22.11.7",
     "esm": "^3.2.25",
     "mocha": "^7.1.1",
     "onchange": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "proseWrap": "always"
   },
   "dependencies": {
+    "@electron/remote": "^1.2.0",
     "@mariotacke/color-thief": "^3.0.1",
     "@primer/octicons": "^9.6.0",
     "@sabaki/boardmatcher": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "devDependencies": {
     "concurrently": "^5.1.0",
-    "electron": "^12.0.0",
+    "electron": "^13.1.4",
     "electron-builder": "^22.11.7",
     "esm": "^3.2.25",
     "mocha": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "devDependencies": {
     "concurrently": "^5.1.0",
-    "electron": "^8.2.1",
+    "electron": "^9.4.4",
     "electron-builder": "^22.4.1",
     "esm": "^3.2.25",
     "mocha": "^7.1.1",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,5 @@
-import {ipcRenderer, remote} from 'electron'
+import {ipcRenderer} from 'electron'
+import * as remote from '@electron/remote'
 import {h, render, Component} from 'preact'
 import classNames from 'classnames'
 import fixPath from 'fix-path'

--- a/src/components/BusyScreen.js
+++ b/src/components/BusyScreen.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 
 const setting = remote.require('./setting')

--- a/src/components/ContentDisplay.js
+++ b/src/components/ContentDisplay.js
@@ -1,4 +1,5 @@
-import {remote, shell} from 'electron'
+import {shell} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 
 import i18n from '../i18n.js'

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -1,6 +1,6 @@
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
-import {remote} from 'electron'
 import sgf from '@sabaki/sgf'
 import {BoundedGoban} from '@sabaki/shudan'
 

--- a/src/components/LeftSidebar.js
+++ b/src/components/LeftSidebar.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 
 import SplitContainer from './helpers/SplitContainer.js'

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -1,5 +1,6 @@
 import {Component} from 'preact'
-import {ipcRenderer, remote} from 'electron'
+import {ipcRenderer} from 'electron'
+import * as remote from '@electron/remote'
 import * as dialog from '../modules/dialog.js'
 import * as menu from '../menu.js'
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import sabaki from '../modules/sabaki.js'
 

--- a/src/components/ThemeManager.js
+++ b/src/components/ThemeManager.js
@@ -1,5 +1,5 @@
 import {join} from 'path'
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import sabaki from '../modules/sabaki.js'
 import ColorThief from '@mariotacke/color-thief'

--- a/src/components/bars/AutoplayBar.js
+++ b/src/components/bars/AutoplayBar.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import {parseVertex} from '@sabaki/sgf'

--- a/src/components/drawers/CleanMarkupDrawer.js
+++ b/src/components/drawers/CleanMarkupDrawer.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 
 import i18n from '../../i18n.js'

--- a/src/components/drawers/GameChooserDrawer.js
+++ b/src/components/drawers/GameChooserDrawer.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 

--- a/src/components/drawers/InfoDrawer.js
+++ b/src/components/drawers/InfoDrawer.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import classNames from 'classnames'
 import {h, Component, toChildArray} from 'preact'
 import Pikaday from 'pikaday'

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -1,5 +1,6 @@
 import {existsSync} from 'fs'
-import {shell, remote} from 'electron'
+import {shell} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import {join} from 'path'

--- a/src/components/drawers/ScoreDrawer.js
+++ b/src/components/drawers/ScoreDrawer.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 

--- a/src/components/sidebars/CommentBox.js
+++ b/src/components/sidebars/CommentBox.js
@@ -1,4 +1,5 @@
-import {remote, shell} from 'electron'
+import {shell} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import boardmatcher from '@sabaki/boardmatcher'

--- a/src/components/sidebars/GameGraph.js
+++ b/src/components/sidebars/GameGraph.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import * as gametree from '../../modules/gametree.js'

--- a/src/components/sidebars/Slider.js
+++ b/src/components/sidebars/Slider.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import * as helper from '../../modules/helper.js'
 

--- a/src/components/sidebars/WinrateGraph.js
+++ b/src/components/sidebars/WinrateGraph.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import i18n from '../../i18n.js'

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,6 +1,10 @@
 const nativeRequire = eval('require')
 
-const {ipcMain, remote} = require('electron')
+const {ipcMain} = require('electron')
+var remote = null
+try {
+  remote = require('@electron/remote')
+} catch (e) {}
 const {readFileSync} = require('fs')
 const path = require('path')
 const {load: dolmLoad, getKey: dolmGetKey} = require('dolm')

--- a/src/main.js
+++ b/src/main.js
@@ -9,9 +9,7 @@ let openfile = null
 
 function newWindow(path) {
   let window = new BrowserWindow({
-    icon: process.platform === 'linux' ?
-      nativeImage.createFromPath(resolve(__dirname, '../logo.png')) :
-      null,
+    icon: nativeImage.createFromPath(resolve(__dirname, '../logo.png')),
     title: app.name,
     useContentSize: true,
     width: setting.get('window.width'),
@@ -23,6 +21,7 @@ function newWindow(path) {
     show: false,
     webPreferences: {
       nodeIntegration: true,
+      enableRemoteModule: true,
       zoomFactor: setting.get('app.zoom_factor')
     }
   })

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,12 @@
-const {app, shell, dialog, ipcMain, nativeImage, BrowserWindow, Menu} = require('electron')
+const {
+  app,
+  shell,
+  dialog,
+  ipcMain,
+  nativeImage,
+  BrowserWindow,
+  Menu
+} = require('electron')
 const {resolve} = require('path')
 const i18n = require('./i18n')
 const setting = require('./setting')

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ const {resolve} = require('path')
 const i18n = require('./i18n')
 const setting = require('./setting')
 const updater = require('./updater')
+require('@electron/remote/main').initialize()
 
 let windows = []
 let openfile = null

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ function newWindow(path) {
     show: false,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false,
       enableRemoteModule: true,
       zoomFactor: setting.get('app.zoom_factor')
     }
@@ -65,8 +66,8 @@ function newWindow(path) {
     if (path) window.webContents.send('load-file', path)
   })
 
-  window.webContents.on('new-window', evt => {
-    evt.preventDefault()
+  window.webContents.setWindowOpenHandler(({url, frameName}) => {
+    return {action: 'deny'}
   })
 
   window.loadURL(`file://${resolve(__dirname, '../index.html')}`)

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const {app, shell, dialog, ipcMain, BrowserWindow, Menu} = require('electron')
+const {app, shell, dialog, ipcMain, nativeImage, BrowserWindow, Menu} = require('electron')
 const {resolve} = require('path')
 const i18n = require('./i18n')
 const setting = require('./setting')
@@ -9,8 +9,9 @@ let openfile = null
 
 function newWindow(path) {
   let window = new BrowserWindow({
-    icon:
-      process.platform === 'linux' ? resolve(__dirname, '../logo.png') : null,
+    icon: process.platform === 'linux' ?
+      nativeImage.createFromPath(resolve(__dirname, '../logo.png')) :
+      null,
     title: app.name,
     useContentSize: true,
     width: setting.get('window.width'),

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,6 +1,10 @@
 const nativeRequire = eval('require')
 
-const {shell, clipboard, remote} = require('electron')
+const {shell, clipboard} = require('electron')
+var remote = null
+try {
+  remote = require('@electron/remote')
+} catch (e) {}
 const isRenderer = remote != null
 const {app} = isRenderer ? remote : require('electron')
 

--- a/src/modules/dialog.js
+++ b/src/modules/dialog.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import i18n from '../i18n.js'
 import sabaki from './sabaki.js'
 import {noop} from './helper.js'

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import EventEmitter from 'events'
 import {existsSync} from 'fs'
 import {dirname, resolve} from 'path'

--- a/src/modules/gtplogger.js
+++ b/src/modules/gtplogger.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import winston from 'winston'
 import {resolve, join} from 'path'
 

--- a/src/modules/helper.js
+++ b/src/modules/helper.js
@@ -102,7 +102,7 @@ export function isTextLikeElement(element) {
 }
 
 export function popupMenu(template, x, y) {
-  const {remote} = require('electron')
+  const remote = require('@electron/remote')
 
   let setting = remote.require('./setting')
   let zoomFactor = +setting.get('app.zoom_factor')

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import EventEmitter from 'events'
 import {basename, extname} from 'path'
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {h} from 'preact'
 import {v4 as uuid} from 'uuid'
 

--- a/src/modules/sound.js
+++ b/src/modules/sound.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import * as remote from '@electron/remote'
 import {wait} from './helper.js'
 
 const setting = remote.require('./setting')


### PR DESCRIPTION
- Bump to electron 9.4.4 and fix incompatibility
- Bump to electron 10.4.7
- Bump electron to v11.4.8
- Update GA workflows to use latest Node LTS
- Replace deprecated remote module with @electron/remote
- Jump to Electron 12.0.0
- Upgrade to final latest electron v13.1.4.
