### PR TITLE
Support WINRATE property

### DIFF
--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -196,7 +196,11 @@ class Sabaki extends EventEmitter {
       get winrateData() {
         return [
           ...this.gameTree.listCurrentNodes(state.gameCurrents[state.gameIndex])
-        ].map(x => x.data.SBKV && x.data.SBKV[0])
+        ].map(
+          x =>
+            (x.data.SBKV && x.data.SBKV[0]) ||
+            (x.data.WINRATE && Math.round(x.data.WINRATE[0] * 10000) / 100)
+        )
       }
     }
   }


### PR DESCRIPTION
Part of #487 .

This lets Sabaki recognize when an SGF file has the non-standard WINRATE property attached to move nodes, in which case it would display a winrate graph even with no engine analysis session running. A winrate value from an engine analysis session would override the value from the SGF file.

Here I assume WINRATE represents the probability of black winning as afloat in [0, 1], but I can change this.