### PR TITLE
Add heatmap from pre-analyzed moves

### DIFF
--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -144,6 +144,7 @@ export default class MainView extends Component {
             analysisTreePosition === treePosition
               ? analysis
               : null,
+          showAnalysis,
           paintMap,
           dimmedStones: ['scoring', 'estimator'].includes(mode)
             ? deadStones

--- a/src/modules/gametree.js
+++ b/src/modules/gametree.js
@@ -358,7 +358,20 @@ export function getBoard(tree, id) {
         type = 'good'
       }
 
-      list[v] = {sign, type}
+      let visits = null
+      let winrate = null
+      let scoreLead = null
+      if (isFinite(node.data.VISITS)) {
+        visits = +node.data.VISITS
+      }
+      if (isFinite(node.data.WINRATE)) {
+        winrate = (0.5 + sign * (node.data.WINRATE - 0.5)) * 100
+      }
+      if (isFinite(node.data.SCORELEAD)) {
+        scoreLead = node.data.SCORELEAD * sign
+      }
+
+      list[v] = {sign, type, visits, winrate, scoreLead}
     }
 
     for (let child of node.children) {


### PR DESCRIPTION
Part of #487 .

This lets Sabaki recognize the non-standard SGF properties VISITS, WINRATE, and SCORELEAD in order to draw a heatmap even with no engine analysis session running. Values from a running engine analysis session would override the values from the SGF.

I assumed the following definitions for these properties, but I can change them:
- VISITS: number of visits
- WINRATE: probability of black winning as a float in [0, 1]
- SCORELEAD: number of points black is winning by

The diff is deceptively large because I indented an existing block by an additional level.

I have written a script that uses KataGo to add these properties to an SGF file: https://github.com/kevinsung/katago-analyze-sgf.

Screenshot:
![Screenshot from 2021-08-07 14-57-46](https://user-images.githubusercontent.com/4296166/128611236-d372ae07-dfb2-47e7-a7da-208181406366.png)
