### PR TITLE
Add score lead line to winrate graph

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -346,6 +346,7 @@ class App extends Component {
         showNextMoves: state.showNextMoves,
         showSiblings: state.showSiblings,
         showWinrateGraph: state.showWinrateGraph,
+        showScoreLeadGraph: state.showScoreLeadGraph,
         showGameGraph: state.showGameGraph,
         showCommentBox: state.showCommentBox,
         showLeftSidebar: state.showLeftSidebar,

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -106,13 +106,15 @@ export default class Sidebar extends Component {
       treePosition,
 
       showWinrateGraph,
+      showScoreLeadGraph,
       showGameGraph,
       showCommentBox,
 
       graphGridSize,
       graphNodeSize,
 
-      winrateData
+      winrateData,
+      scoreLeadData
     },
     {winrateGraphHeight, sidebarSplit}
   ) {
@@ -140,6 +142,8 @@ export default class Sidebar extends Component {
           lastPlayer,
           width: winrateGraphWidth,
           data: winrateData,
+          scoreLeadData: scoreLeadData,
+          showScoreLeadGraph: showScoreLeadGraph,
           currentIndex: level,
           onCurrentIndexChange: this.handleWinrateGraphChange
         }),
@@ -230,8 +234,14 @@ export default class Sidebar extends Component {
   }
 }
 
-Sidebar.getDerivedStateFromProps = function({showWinrateGraph, winrateData}) {
+Sidebar.getDerivedStateFromProps = function({
+  showWinrateGraph,
+  winrateData,
+  showScoreLeadGraph,
+  scoreLeadData
+}) {
   return {
-    showWinrateGraph: showWinrateGraph && winrateData.some(x => x != null)
+    showWinrateGraph: showWinrateGraph && winrateData.some(x => x != null),
+    showScoreLeadGraph: showScoreLeadGraph && scoreLeadData.some(x => x != null)
   }
 }

--- a/src/menu.js
+++ b/src/menu.js
@@ -33,6 +33,7 @@ exports.get = function(props = {}) {
     showNextMoves,
     showSiblings,
     showWinrateGraph,
+    showScoreLeadGraph,
     showGameGraph,
     showCommentBox,
     showLeftSidebar,
@@ -680,6 +681,18 @@ exports.get = function(props = {}) {
             toggleSetting('view.show_winrategraph')
             sabaki.setState(({showWinrateGraph}) => ({
               showWinrateGraph: !showWinrateGraph
+            }))
+          }
+        },
+        {
+          label: i18n.t('menu.view', 'Show &Score Lead Graph'),
+          type: 'checkbox',
+          checked: !!showScoreLeadGraph,
+          enabled: !!showGameGraph || !!showCommentBox,
+          click: () => {
+            toggleSetting('view.show_scoreleadgraph')
+            sabaki.setState(({showScoreLeadGraph}) => ({
+              showScoreLeadGraph: !showScoreLeadGraph
             }))
           }
         },

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -145,7 +145,10 @@ export default class EngineSyncer extends EventEmitter {
               this.analysis = {
                 sign,
                 variations,
-                winrate: Math.max(...variations.map(({winrate}) => winrate))
+                winrate: Math.max(...variations.map(({winrate}) => winrate)),
+                scoreLead: Math.max(
+                  ...variations.map(({scoreLead}) => scoreLead)
+                )
               }
             } else if (line.startsWith('play ')) {
               sign = -sign

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -76,6 +76,7 @@ class Sabaki extends EventEmitter {
       showLeftSidebar: setting.get('view.show_leftsidebar'),
       leftSidebarWidth: setting.get('view.leftsidebar_width'),
       showWinrateGraph: setting.get('view.show_winrategraph'),
+      showScoreLeadGraph: setting.get('view.show_scoreleadgraph'),
       showGameGraph: setting.get('view.show_graph'),
       showCommentBox: setting.get('view.show_comments'),
       sidebarWidth: setting.get('view.sidebar_width'),
@@ -197,6 +198,11 @@ class Sabaki extends EventEmitter {
         return [
           ...this.gameTree.listCurrentNodes(state.gameCurrents[state.gameIndex])
         ].map(x => x.data.SBKV && x.data.SBKV[0])
+      },
+      get scoreLeadData() {
+        return [
+          ...this.gameTree.listCurrentNodes(state.gameCurrents[state.gameIndex])
+        ].map(x => x.data.SBKS && x.data.SBKS[0])
       }
     }
   }
@@ -1691,12 +1697,16 @@ class Sabaki extends EventEmitter {
 
           if (syncer.analysis != null && syncer.treePosition != null) {
             let tree = this.state.gameTrees[this.state.gameIndex]
-            let {sign, winrate} = syncer.analysis
+            let {sign, winrate, scoreLead} = syncer.analysis
             if (sign < 0) winrate = 100 - winrate
+            if (sign < 0) scoreLead = 0 - scoreLead
 
             let newTree = tree.mutate(draft => {
               draft.updateProperty(syncer.treePosition, 'SBKV', [
                 (Math.round(winrate * 100) / 100).toString()
+              ])
+              draft.updateProperty(syncer.treePosition, 'SBKS', [
+                (Math.round(scoreLead * 100) / 100).toString()
               ])
             })
 

--- a/src/setting.js
+++ b/src/setting.js
@@ -202,6 +202,7 @@ let defaults = {
   'view.show_next_moves': true,
   'view.show_siblings': true,
   'view.show_winrategraph': true,
+  'view.show_scoreleadgraph': true,
   'view.sidebar_width': 200,
   'view.sidebar_minwidth': 100,
   'view.winrategraph_blunderthreshold': 5,


### PR DESCRIPTION
Early PR at this stage, would welcome some suggestions to make cleaner. and for how to do the i18n correctly.

Content of this PR:
- When analyzing with katago,  black's score lead is added to a node property `SBKS` <-- Welcoming a better suggestion for the node property name
- Adds an toggleable option to display the score lead graph `Show Score Lead Graph`
- Adds a blue line representing score lead as an overlay to winrate graph
- Adds score lead in tooltip

Example image:
<img width="1309" alt="Screen Shot 2021-09-08 at 1 06 16" src="https://user-images.githubusercontent.com/6682272/132378393-5b5c5523-40f6-47d1-9dc3-9821e74485b3.png">
