### PR TITLE
Support displaying score lead in analysis graph

### DIFF
--- a/e2e/analysis-graph.spec.js
+++ b/e2e/analysis-graph.spec.js
@@ -120,4 +120,19 @@ test.describe('Analysis Graph', () => {
     // A score lead of 0 is a real, common value; the marker must still render.
     expect(await markerCount(page)).toBe(1)
   })
+
+  test('updates the data line when the metric is toggled at an unanalysed node', async ({
+    page,
+  }) => {
+    await goToStep(page, 0) // root: no SBKV/SBKS → data[currentIndex] == null
+    const winratePath = await dataLinePath(page)
+    expect(winratePath).toBeTruthy()
+
+    await setMetric(page, 'scoreLead')
+    const scoreLeadPath = await dataLinePath(page)
+
+    // data[currentIndex] is null for both metrics here, so the re-render must
+    // be driven by the analysisType change, not the current value.
+    expect(scoreLeadPath).not.toBe(winratePath)
+  })
 })

--- a/e2e/analysis-graph.spec.js
+++ b/e2e/analysis-graph.spec.js
@@ -1,0 +1,113 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// Tests for the analysis graph's two metrics (win rate and score lead).
+//
+// The analysis graph reads its series from the SBKV (win rate) and SBKS (score
+// lead) SGF properties, so we can exercise it by loading an SGF that already
+// carries those values — no live engine needed. We force the sidebar open via
+// state so the graph is laid out, then assert against the rendered DOM:
+//   - the position marker:   #winrategraph .marker
+//   - the value strip:       #winrategraph .main
+//   - the data line path:    #winrategraph svg path[stroke="#eee"]
+
+// SGF whose four main-line moves all carry SBKV + SBKS. Note dp (move 3) has a
+// score lead of exactly 0 — the realistic "even game" case.
+//   index:        0(root) 1(dd) 2(pp)  3(dp) 4(pd)
+//   winrate:        –       55    48     60    52
+//   scoreLead:      –      1.5   -0.5     0     2
+const SGF =
+  '(;GM[1]FF[4]CA[UTF-8]SZ[19]' +
+  ';B[dd]SBKV[55]SBKS[1.5]' +
+  ';W[pp]SBKV[48]SBKS[-0.5]' +
+  ';B[dp]SBKV[60]SBKS[0]' +
+  ';W[pd]SBKV[52]SBKS[2])'
+
+// --- helpers ---------------------------------------------------------------
+
+async function loadGraph(page) {
+  await loadSgfStringAndWait(page, SGF)
+  // Show the game graph so the sidebar (and thus the analysis graph) is laid
+  // out with a real size. winrateData has non-null values, so the graph passes
+  // its visibility gate.
+  await page.evaluate(() => window.__sabaki.setState({showGameGraph: true}))
+  await page.waitForSelector('#winrategraph', {timeout: 10000})
+  await waitForRender(page)
+}
+
+async function setMetric(page, type) {
+  await page.evaluate(async (t) => {
+    await window.sabaki.setting.set('board.analysis_type', t)
+  }, type)
+  await page.waitForFunction(
+    (t) => window.__sabaki.state.analysisType === t,
+    type,
+  )
+  await waitForRender(page)
+}
+
+async function goToStep(page, n) {
+  await page.evaluate((steps) => {
+    window.__sabaki.goToBeginning()
+    for (let i = 0; i < steps; i++) window.__sabaki.goStep(1)
+  }, n)
+  await waitForRender(page)
+}
+
+const markerCount = (page) =>
+  page.evaluate(() => document.querySelectorAll('#winrategraph .marker').length)
+
+const stripText = (page) =>
+  page.evaluate(() => {
+    const el = document.querySelector('#winrategraph .main')
+    return el ? el.textContent : null
+  })
+
+const dataLinePath = (page) =>
+  page.evaluate(() => {
+    const p = document.querySelector('#winrategraph svg path[stroke="#eee"]')
+    return p ? p.getAttribute('d') : null
+  })
+
+// --- tests -----------------------------------------------------------------
+
+test.describe('Analysis Graph', () => {
+  test.beforeEach(async ({page}) => {
+    await loadGraph(page)
+  })
+
+  test('win-rate graph renders with a position marker', async ({page}) => {
+    // Default analysisType is 'winrate'.
+    await goToStep(page, 4) // pd, winrate 52
+    expect(await markerCount(page)).toBe(1)
+    expect(await stripText(page)).toContain('%')
+  })
+
+  test('score-lead mode renders values without a percent sign', async ({
+    page,
+  }) => {
+    await setMetric(page, 'scoreLead')
+    await goToStep(page, 4) // pd, score lead 2
+
+    expect(await stripText(page)).not.toContain('%')
+    expect(await stripText(page)).toMatch(/\d/)
+    // Score lead here is 2 (non-zero), so the marker is shown.
+    expect(await markerCount(page)).toBe(1)
+  })
+
+  test('toggling the metric updates the data line at an analysed node', async ({
+    page,
+  }) => {
+    await goToStep(page, 4) // pd has both winrate (52) and score lead (2)
+    const winratePath = await dataLinePath(page)
+
+    await setMetric(page, 'scoreLead')
+    const scoreLeadPath = await dataLinePath(page)
+
+    // data[currentIndex] differs between metrics here, so the graph
+    // re-renders and the curve changes.
+    expect(scoreLeadPath).not.toBe(winratePath)
+    expect(winratePath).toBeTruthy()
+  })
+})

--- a/e2e/analysis-graph.spec.js
+++ b/e2e/analysis-graph.spec.js
@@ -110,4 +110,14 @@ test.describe('Analysis Graph', () => {
     expect(scoreLeadPath).not.toBe(winratePath)
     expect(winratePath).toBeTruthy()
   })
+
+  test('keeps the position marker visible when the score lead is exactly 0', async ({
+    page,
+  }) => {
+    await setMetric(page, 'scoreLead')
+    await goToStep(page, 3) // dp, score lead == 0 (an even position)
+
+    // A score lead of 0 is a real, common value; the marker must still render.
+    expect(await markerCount(page)).toBe(1)
+  })
 })

--- a/e2e/analysis-graph.spec.js
+++ b/e2e/analysis-graph.spec.js
@@ -12,17 +12,19 @@ const {loadSgfStringAndWait, waitForRender} = require('./helpers')
 //   - the value strip:       #winrategraph .main
 //   - the data line path:    #winrategraph svg path[stroke="#eee"]
 
-// SGF whose four main-line moves all carry SBKV + SBKS. Note dp (move 3) has a
-// score lead of exactly 0 — the realistic "even game" case.
-//   index:        0(root) 1(dd) 2(pp)  3(dp) 4(pd)
-//   winrate:        –       55    48     60    52
-//   scoreLead:      –      1.5   -0.5     0     2
+// SGF whose main-line moves carry SBKV + SBKS. Note dp (move 3) has a score
+// lead of exactly 0 (the "even game" case), and jj (move 5) has a malformed,
+// non-numeric SBKS that coerces to NaN.
+//   index:        0(root) 1(dd) 2(pp)  3(dp) 4(pd) 5(jj)
+//   winrate:        –       55    48     60    52    50
+//   scoreLead:      –      1.5   -0.5     0     2    NaN (malformed "x")
 const SGF =
   '(;GM[1]FF[4]CA[UTF-8]SZ[19]' +
   ';B[dd]SBKV[55]SBKS[1.5]' +
   ';W[pp]SBKV[48]SBKS[-0.5]' +
   ';B[dp]SBKV[60]SBKS[0]' +
-  ';W[pd]SBKV[52]SBKS[2])'
+  ';W[pd]SBKV[52]SBKS[2]' +
+  ';B[jj]SBKV[50]SBKS[x])'
 
 // --- helpers ---------------------------------------------------------------
 
@@ -119,6 +121,17 @@ test.describe('Analysis Graph', () => {
 
     // A score lead of 0 is a real, common value; the marker must still render.
     expect(await markerCount(page)).toBe(1)
+  })
+
+  test('hides the position marker when the value is non-numeric (NaN)', async ({
+    page,
+  }) => {
+    await setMetric(page, 'scoreLead')
+    await goToStep(page, 5) // jj, malformed SBKS → NaN
+
+    // A NaN value must not render a marker (it would be positioned at top: NaN%);
+    // the finite-number guard hides it, unlike a plain `!= null` check.
+    expect(await markerCount(page)).toBe(0)
   })
 
   test('updates the data line when the metric is toggled at an unanalysed node', async ({

--- a/e2e/engine-analysis.spec.js
+++ b/e2e/engine-analysis.spec.js
@@ -8,8 +8,8 @@ const {
 } = require('./helpers')
 
 // End-to-end coverage of the analysis pipeline: attach an engine, start
-// analysis, and confirm the engine's reported win rate is written onto the
-// current node as the SBKV property.
+// analysis, and confirm the engine's reported win rate and score lead are
+// written onto the current node as the SBKV and SBKS properties.
 //
 // The engine here is test/engines/replayEngine.js, which replays a GOLDEN
 // TRANSCRIPT — real `info ...` lines recorded from KataGo by
@@ -38,7 +38,7 @@ const SGF = path.join(RES, 'sgf', 'endgame-9.sgf')
 const TRANSCRIPT = path.join(RES, 'katago-1.16.4', 'endgame-9.kata-analyze.txt')
 
 test.describe('Engine Analysis Integration', () => {
-  test('replayed KataGo analysis writes a decisive SBKV onto the current node', async ({
+  test('replayed KataGo analysis writes decisive SBKV and SBKS onto the current node', async ({
     page,
   }) => {
     await loadSgfAndWait(page, SGF)
@@ -91,6 +91,21 @@ test.describe('Engine Analysis Integration', () => {
       expect(Number.isFinite(winrate)).toBe(true)
       expect(winrate).toBeGreaterThan(85)
       expect(winrate).toBeLessThanOrEqual(100)
+
+      // SBKS is the score lead, written in the same update as SBKV and likewise
+      // normalized to Black's perspective. Black is decisively ahead here, so it
+      // must be a finite, clearly positive lead — this pins the score-lead
+      // extraction and its sign (a wrong flip would go negative).
+      const sbks = await page.evaluate(() => {
+        const s = window.__sabaki
+        const tree = s.state.gameTrees[s.state.gameIndex]
+        return tree.get(s.state.treePosition).data.SBKS[0]
+      })
+
+      const scoreLead = parseFloat(sbks)
+      expect(Number.isFinite(scoreLead)).toBe(true)
+      expect(scoreLead).toBeGreaterThan(1)
+      expect(scoreLead).toBeLessThan(50)
     } finally {
       await page.evaluate(() => window.__sabaki.stopAnalysis())
       await detachAndWait(page, [syncerId])

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -24,5 +24,10 @@ module.exports = defineConfig({
       testMatch: /move-numbers\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'analysis-graph',
+      testMatch: /analysis-graph\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -107,6 +107,7 @@ export default class Sidebar extends Component {
       gameCurrents,
       treePosition,
 
+      analysisType,
       showWinrateGraph,
       showGameGraph,
       showCommentBox,
@@ -115,6 +116,7 @@ export default class Sidebar extends Component {
       graphNodeSize,
 
       winrateData,
+      scoreLeadData,
     },
     {winrateGraphHeight, sidebarSplit},
   ) {
@@ -141,7 +143,8 @@ export default class Sidebar extends Component {
         sideContent: h(WinrateGraph, {
           lastPlayer,
           width: winrateGraphWidth,
-          data: winrateData,
+          data: analysisType === 'winrate' ? winrateData : scoreLeadData,
+          analysisType,
           currentIndex: level,
           onCurrentIndexChange: this.handleWinrateGraphChange,
         }),

--- a/src/components/drawers/CleanMarkupDrawer.js
+++ b/src/components/drawers/CleanMarkupDrawer.js
@@ -67,7 +67,7 @@ export default class CleanMarkupDrawer extends Component {
           comments: ['C', 'N'],
           annotations: ['DM', 'GB', 'GW', 'UC', 'BM', 'DO', 'IT', 'TE'],
           hotspots: ['HO'],
-          winrate: ['SBKV'],
+          winrate: ['SBKV', 'SBKS'],
         }
 
         let properties = Object.keys(data)
@@ -188,7 +188,7 @@ export default class CleanMarkupDrawer extends Component {
           }),
           h(CleanMarkupItem, {
             id: 'cleanmarkup.winrate',
-            text: t('Winrate data'),
+            text: t('Analysis data'),
           }),
         ),
 

--- a/src/components/sidebars/WinrateGraph.js
+++ b/src/components/sidebars/WinrateGraph.js
@@ -9,11 +9,26 @@ const setting = {
   get: (key) => window.sabaki.setting.get(key),
   onDidChange: (callback) => window.sabaki.setting.onDidChange(callback),
 }
-const blunderThreshold = setting.get('view.winrategraph_blunderthreshold')
+const blunderThresholdWinrate = setting.get(
+  'view.winrategraph_blunderthreshold',
+)
+const blunderThresholdScoreLead = setting.get(
+  'view.winrategraph_blunderthreshold_scorelead',
+)
+
+const formatAnalysisValue = (value, analysisType) => {
+  if (analysisType === 'winrate') return `${i18n.formatNumber(value)}%`
+  return `${value >= 0 ? '+' : ''}${i18n.formatNumber(value)}`
+}
+
+const transformAnalysisValue = (value, analysisType, dataMax) => {
+  if (analysisType === 'winrate') return value
+  return (value / Math.max(20, dataMax)) * 50 + 50
+}
 
 class WinrateStrip extends Component {
   render() {
-    let {player, winrate, change} = this.props
+    let {player, winrate, change, analysisType, blunderThreshold} = this.props
 
     return h(
       'section',
@@ -30,7 +45,7 @@ class WinrateStrip extends Component {
       h(
         'span',
         {class: 'main'},
-        winrate == null ? '–' : `${i18n.formatNumber(winrate)}%`,
+        winrate == null ? '–' : formatAnalysisValue(winrate, analysisType),
       ),
 
       h(
@@ -104,15 +119,24 @@ export default class WinrateGraph extends Component {
   }
 
   render() {
-    let {lastPlayer, width, currentIndex, data} = this.props
+    let {lastPlayer, width, currentIndex, data, analysisType} = this.props
     let {invert} = this.state
+    let blunderThreshold =
+      analysisType === 'winrate'
+        ? blunderThresholdWinrate
+        : blunderThresholdScoreLead
+    let metricString = analysisType === 'winrate' ? 'Winrate' : 'Score Lead'
 
+    let dataMax = Math.max(...data.map((x) => (isFinite(x) ? Math.abs(x) : 0)))
     let dataDiff = data.map((x, i) =>
       i === 0 || x == null || (data[i - 1] == null && data[i - 2] == null)
         ? null
         : x - data[data[i - 1] != null ? i - 1 : i - 2],
     )
-    let dataDiffMax = Math.max(...dataDiff.map(Math.abs), 25)
+    let dataDiffMax = Math.max(
+      ...dataDiff.map(Math.abs),
+      analysisType === 'winrate' ? 25 : 10,
+    )
 
     let round2 = (x) => Math.round(x * 100) / 100
     let blackWinrate =
@@ -120,7 +144,13 @@ export default class WinrateGraph extends Component {
     let blackWinrateDiff =
       dataDiff[currentIndex] == null ? null : round2(dataDiff[currentIndex])
     let whiteWinrate =
-      data[currentIndex] == null ? null : round2(100 - data[currentIndex])
+      data[currentIndex] == null
+        ? null
+        : round2(
+            analysisType === 'winrate'
+              ? 100 - data[currentIndex]
+              : -data[currentIndex],
+          )
     let whiteWinrateDiff =
       dataDiff[currentIndex] == null ? null : -round2(dataDiff[currentIndex])
 
@@ -134,8 +164,10 @@ export default class WinrateGraph extends Component {
             .map(
               ([winrate, diff], i) =>
                 `${
-                  i === 0 ? t('Black Winrate:') : t('White Winrate:')
-                } ${i18n.formatNumber(winrate)}%${
+                  i === 0
+                    ? t(`Black ${metricString}:`)
+                    : t(`White ${metricString}:`)
+                } ${formatAnalysisValue(winrate, analysisType)}${
                   diff == null
                     ? ''
                     : ` (${diff >= 0 ? '+' : '-'}${i18n.formatNumber(
@@ -159,6 +191,8 @@ export default class WinrateGraph extends Component {
         player: lastPlayer,
         winrate: lastPlayer > 0 ? blackWinrate : whiteWinrate,
         change: lastPlayer > 0 ? blackWinrateDiff : whiteWinrateDiff,
+        analysisType,
+        blunderThreshold,
       }),
 
       h(
@@ -217,7 +251,10 @@ export default class WinrateGraph extends Component {
                   let instructions = data
                     .map((x, i) => {
                       if (x == null) return i === 0 ? [i, 50] : null
-                      return [i, x]
+                      return [
+                        i,
+                        transformAnalysisValue(x, analysisType, dataMax),
+                      ]
                     })
                     .filter((x) => x != null)
 
@@ -311,7 +348,11 @@ export default class WinrateGraph extends Component {
                 if (x == null) return ''
 
                 let command = i === 0 || data[i - 1] == null ? 'M' : 'L'
-                return `${command} ${i},${x}`
+                return `${command} ${i},${transformAnalysisValue(
+                  x,
+                  analysisType,
+                  dataMax,
+                )}`
               })
               .join(' '),
           }),
@@ -328,9 +369,18 @@ export default class WinrateGraph extends Component {
                 if (i === 0) return 'M 0,50'
 
                 if (x == null && data[i - 1] != null)
-                  return `M ${i - 1},${data[i - 1]}`
+                  return `M ${i - 1},${transformAnalysisValue(
+                    data[i - 1],
+                    analysisType,
+                    dataMax,
+                  )}`
 
-                if (x != null && data[i - 1] == null) return `L ${i},${x}`
+                if (x != null && data[i - 1] == null)
+                  return `L ${i},${transformAnalysisValue(
+                    x,
+                    analysisType,
+                    dataMax,
+                  )}`
 
                 return ''
               })
@@ -345,7 +395,20 @@ export default class WinrateGraph extends Component {
             class: 'marker',
             style: {
               left: `${(currentIndex * 100) / width}%`,
-              top: `${!invert ? data[currentIndex] : 100 - data[currentIndex]}%`,
+              top: `${
+                !invert
+                  ? transformAnalysisValue(
+                      data[currentIndex],
+                      analysisType,
+                      dataMax,
+                    )
+                  : 100 -
+                    transformAnalysisValue(
+                      data[currentIndex],
+                      analysisType,
+                      dataMax,
+                    )
+              }%`,
             },
           }),
       ),

--- a/src/components/sidebars/WinrateGraph.js
+++ b/src/components/sidebars/WinrateGraph.js
@@ -397,10 +397,12 @@ export default class WinrateGraph extends Component {
 
         // Draw marker
 
-        // Guard with `!= null`, not truthiness: the series is numeric, so a
-        // value of exactly 0 (an even score lead, or 0% win rate) is falsy and
-        // would otherwise drop the marker.
-        data[currentIndex] != null &&
+        // Guard with Number.isFinite, not truthiness or `!= null`: the series
+        // is numeric, so 0 (an even score lead / 0% win rate) must still show
+        // the marker, while a non-numeric value — a malformed SGF property
+        // coerces via +x to NaN — must not (`!= null` would let NaN reach
+        // `top: NaN%`).
+        Number.isFinite(data[currentIndex]) &&
           h('div', {
             class: 'marker',
             style: {

--- a/src/components/sidebars/WinrateGraph.js
+++ b/src/components/sidebars/WinrateGraph.js
@@ -88,12 +88,19 @@ export default class WinrateGraph extends Component {
     }
   }
 
-  shouldComponentUpdate({lastPlayer, width, currentIndex, data}, {invert}) {
+  shouldComponentUpdate(
+    {lastPlayer, width, currentIndex, data, analysisType},
+    {invert},
+  ) {
     return (
       lastPlayer !== this.props.lastPlayer ||
       width !== this.props.width ||
       currentIndex !== this.props.currentIndex ||
       data[currentIndex] !== this.props.data[currentIndex] ||
+      // Without this, toggling the metric while data[currentIndex] is equal
+      // across metrics (e.g. null at an unanalysed node) skips the re-render and
+      // the whole curve never switches.
+      analysisType !== this.props.analysisType ||
       invert !== this.state.invert
     )
   }

--- a/src/components/sidebars/WinrateGraph.js
+++ b/src/components/sidebars/WinrateGraph.js
@@ -390,7 +390,10 @@ export default class WinrateGraph extends Component {
 
         // Draw marker
 
-        data[currentIndex] &&
+        // Guard with `!= null`, not truthiness: the series is numeric, so a
+        // value of exactly 0 (an even score lead, or 0% win rate) is falsy and
+        // would otherwise drop the marker.
+        data[currentIndex] != null &&
           h('div', {
             class: 'marker',
             style: {

--- a/src/menu.js
+++ b/src/menu.js
@@ -580,6 +580,39 @@ exports.get = function (props = {}) {
           click: () =>
             sabaki.setState(({fullScreen}) => ({fullScreen: !fullScreen})),
         },
+        {
+          label: i18n.t('menu.view', 'Analysis Metric'),
+          submenu: [
+            {
+              label: i18n.t('menu.view', '&Win Rate'),
+              type: 'checkbox',
+              checked: analysisType === 'winrate',
+              accelerator: 'CmdOrCtrl+Shift+H',
+              click: () => {
+                setting.set(
+                  'board.analysis_type',
+                  setting.get('board.analysis_type') === 'winrate'
+                    ? 'scoreLead'
+                    : 'winrate',
+                )
+              },
+            },
+            {
+              label: i18n.t('menu.view', '&Score Lead'),
+              type: 'checkbox',
+              checked: analysisType === 'scoreLead',
+              accelerator: 'CmdOrCtrl+Shift+H',
+              click: () => {
+                setting.set(
+                  'board.analysis_type',
+                  setting.get('board.analysis_type') === 'scoreLead'
+                    ? 'winrate'
+                    : 'scoreLead',
+                )
+              },
+            },
+          ],
+        },
         {type: 'separator'},
         {
           label: i18n.t('menu.view', 'Show &Coordinates'),
@@ -680,50 +713,14 @@ exports.get = function (props = {}) {
         },
         {
           label: i18n.t('menu.view', 'Show &Heatmap'),
-          submenu: [
-            {
-              label: i18n.t('menu.view', '&Don’t Show'),
-              type: 'checkbox',
-              checked: !showAnalysis,
-              accelerator: 'CmdOrCtrl+H',
-              click: () => toggleSetting('board.show_analysis'),
-            },
-            {type: 'separator'},
-            {
-              label: i18n.t('menu.view', 'Show &Win Rate'),
-              type: 'checkbox',
-              checked: !!showAnalysis && analysisType === 'winrate',
-              accelerator: 'CmdOrCtrl+Shift+H',
-              click: () => {
-                setting.set('board.show_analysis', true)
-                setting.set(
-                  'board.analysis_type',
-                  setting.get('board.analysis_type') === 'winrate'
-                    ? 'scoreLead'
-                    : 'winrate',
-                )
-              },
-            },
-            {
-              label: i18n.t('menu.view', 'Show &Score Lead'),
-              type: 'checkbox',
-              checked: !!showAnalysis && analysisType === 'scoreLead',
-              accelerator: 'CmdOrCtrl+Shift+H',
-              click: () => {
-                setting.set('board.show_analysis', true)
-                setting.set(
-                  'board.analysis_type',
-                  setting.get('board.analysis_type') === 'scoreLead'
-                    ? 'winrate'
-                    : 'scoreLead',
-                )
-              },
-            },
-          ],
+          type: 'checkbox',
+          checked: !!showAnalysis,
+          accelerator: 'CmdOrCtrl+H',
+          click: () => toggleSetting('board.show_analysis'),
         },
         {type: 'separator'},
         {
-          label: i18n.t('menu.view', 'Show &Winrate Graph'),
+          label: i18n.t('menu.view', 'Show &Analysis Graph'),
           type: 'checkbox',
           checked: !!showWinrateGraph,
           enabled: !!showGameGraph || !!showCommentBox,

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -114,6 +114,11 @@ export default class EngineSyncer extends EventEmitter {
                 sign,
                 variations,
                 winrate: Math.max(...variations.map(({winrate}) => winrate)),
+                scoreLead: Math.max(
+                  ...variations.map(({scoreLead}) =>
+                    scoreLead == null ? NaN : scoreLead,
+                  ),
+                ),
               }
             } else if (line.startsWith('play ')) {
               sign = -sign

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -290,7 +290,14 @@ class Sabaki extends EventEmitter {
           ...this.gameTree.listCurrentNodes(
             state.gameCurrents[state.gameIndex],
           ),
-        ].map((x) => x.data.SBKV && x.data.SBKV[0])
+        ].map((x) => x.data.SBKV && +x.data.SBKV[0])
+      },
+      get scoreLeadData() {
+        return [
+          ...this.gameTree.listCurrentNodes(
+            state.gameCurrents[state.gameIndex],
+          ),
+        ].map((x) => x.data.SBKS && +x.data.SBKS[0])
       },
     }
   }
@@ -977,14 +984,18 @@ class Sabaki extends EventEmitter {
               Math.round(
                 (sign > 0 ? variation.winrate : 100 - variation.winrate) * 100,
               ) / 100
-
+            let startNodeProperties = {
+              [annotationProp]: [annotationValues[annotationProp]],
+              SBKV: [winrate.toString()],
+            }
+            if (variation.scoreLead != null) {
+              let scoreLead = Math.round(sign * variation.scoreLead * 100) / 100
+              startNodeProperties.SBKS = [scoreLead.toString()]
+            }
             this.openVariationMenu(sign, variation.moves, {
               x,
               y,
-              startNodeProperties: {
-                [annotationProp]: [annotationValues[annotationProp]],
-                SBKV: [winrate.toString()],
-              },
+              startNodeProperties,
             })
           }
         }
@@ -1831,13 +1842,21 @@ class Sabaki extends EventEmitter {
 
           if (syncer.analysis != null && syncer.treePosition != null) {
             let tree = this.state.gameTrees[this.state.gameIndex]
-            let {sign, winrate} = syncer.analysis
-            if (sign < 0) winrate = 100 - winrate
+            let {sign, winrate, scoreLead} = syncer.analysis
+            if (sign < 0) {
+              winrate = 100 - winrate
+              scoreLead = -scoreLead
+            }
 
             let newTree = tree.mutate((draft) => {
               draft.updateProperty(syncer.treePosition, 'SBKV', [
                 (Math.round(winrate * 100) / 100).toString(),
               ])
+              if (isFinite(scoreLead)) {
+                draft.updateProperty(syncer.treePosition, 'SBKS', [
+                  (Math.round(scoreLead * 100) / 100).toString(),
+                ])
+              }
             })
 
             this.setCurrentTreePosition(newTree, this.state.treePosition)

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -988,7 +988,7 @@ class Sabaki extends EventEmitter {
               [annotationProp]: [annotationValues[annotationProp]],
               SBKV: [winrate.toString()],
             }
-            if (variation.scoreLead != null) {
+            if (Number.isFinite(variation.scoreLead)) {
               let scoreLead = Math.round(sign * variation.scoreLead * 100) / 100
               startNodeProperties.SBKS = [scoreLead.toString()]
             }

--- a/src/setting.js
+++ b/src/setting.js
@@ -206,6 +206,7 @@ let defaults = {
   'view.sidebar_width': 200,
   'view.sidebar_minwidth': 100,
   'view.winrategraph_blunderthreshold': 5,
+  'view.winrategraph_blunderthreshold_scorelead': 2,
   'view.winrategraph_height': 90,
   'view.winrategraph_minheight': 30,
   'view.winrategraph_maxheight': 250,


### PR DESCRIPTION
Fixes #755 . Closes #823 .

This PR is an alternative to #823. I did explain the issues with that PR in the comments there, but since this feature is a high priority for me I went ahead and implemented it myself. In contrast to #823, which adds a score lead line on top of the existing graph, this PR makes the graph show either win rate or score lead, but not both, with the same style in either case. The metric (winrate or score lead) shown on the graph always matches the metric shown in the heatmap.

There are many variables in the code that use the term "winrate" which is no longer accurate after this change, since it can mean either "winrate" or "score lead". To keep the diff small, I did not change those variable names in this PR. Those variables should probably be renamed in a future PR.

Screenshots (second image taken after clicking "Score Lead" in first image):
![Screenshot from 2021-10-11 11-58-20](https://user-images.githubusercontent.com/4296166/136820661-039ea833-bf13-40f7-b717-601de444e333.png)
![Screenshot from 2021-10-11 11-58-24](https://user-images.githubusercontent.com/4296166/136820681-c9a82556-40a4-4df9-b4ad-08d6f9051617.png)

