### PR TITLE
Issue 773 - cycle through downstream variations

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -411,12 +411,12 @@ exports.get = function(props = {}) {
           click: () => sabaki.goToSiblingVariation(1)
         },
         {
-          label: i18n.t('menu.navigation', 'Decrement Downstream &Variation'),
+          label: i18n.t('menu.navigation', '&Decrement Downstream Variation'),
           accelerator: 'Left',
           click: () => sabaki.changeDownstreamVariation(-1)
         },
         {
-          label: i18n.t('menu.navigation', 'Increment Downstream Va&riation'),
+          label: i18n.t('menu.navigation', '&Increment Downstream Variation'),
           accelerator: 'Right',
           click: () => sabaki.changeDownstreamVariation(1)
         },

--- a/src/menu.js
+++ b/src/menu.js
@@ -402,13 +402,23 @@ exports.get = function(props = {}) {
         },
         {
           label: i18n.t('menu.navigation', 'Go to Previous &Variation'),
-          accelerator: 'Left',
+          accelerator: 'Shift+Left',
           click: () => sabaki.goToSiblingVariation(-1)
         },
         {
           label: i18n.t('menu.navigation', 'Go to Next Va&riation'),
-          accelerator: 'Right',
+          accelerator: 'Shift+Right',
           click: () => sabaki.goToSiblingVariation(1)
+        },
+        {
+          label: i18n.t('menu.navigation', 'Decrement Downstream &Variation'),
+          accelerator: 'Left',
+          click: () => sabaki.changeDownstreamVariation(-1)
+        },
+        {
+          label: i18n.t('menu.navigation', 'Increment Downstream Va&riation'),
+          accelerator: 'Right',
+          click: () => sabaki.changeDownstreamVariation(1)
         },
         {type: 'separator'},
         {

--- a/src/menu.js
+++ b/src/menu.js
@@ -402,22 +402,22 @@ exports.get = function(props = {}) {
         },
         {
           label: i18n.t('menu.navigation', 'Go to Previous &Variation'),
-          accelerator: 'Shift+Left',
+          accelerator: 'Left',
           click: () => sabaki.goToSiblingVariation(-1)
         },
         {
           label: i18n.t('menu.navigation', 'Go to Next Va&riation'),
-          accelerator: 'Shift+Right',
+          accelerator: 'Right',
           click: () => sabaki.goToSiblingVariation(1)
         },
         {
           label: i18n.t('menu.navigation', '&Decrement Downstream Variation'),
-          accelerator: 'Left',
+          accelerator: 'Shift+Left',
           click: () => sabaki.changeDownstreamVariation(-1)
         },
         {
           label: i18n.t('menu.navigation', '&Increment Downstream Variation'),
-          accelerator: 'Right',
+          accelerator: 'Shift+Right',
           click: () => sabaki.changeDownstreamVariation(1)
         },
         {type: 'separator'},

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1563,11 +1563,11 @@ class Sabaki extends EventEmitter {
     let next = tree.navigate(node.id, 1, currents)
     if (next == null) return
     let lowestFork = node
-    while (next != null) { //not at a leaf
+    while (next != null) {
       if (next.id != node.children.slice(chIdx[0])[0].id) {
-        lowestFork = node;
+        lowestFork = node
       }
-      sequence = [...tree.getSequence(next.id)];
+      sequence = [...tree.getSequence(next.id)]
       node = sequence.slice(-1)[0]
       next = tree.navigate(node.id, 1, currents)
     }
@@ -1582,13 +1582,15 @@ class Sabaki extends EventEmitter {
     next = tree.navigate(lowestFork.id, 1, currents) //using new currents
 
     // then zero the downstream currents.
-    while (next.id != null) { //not at a leaf
-      sequence = [...tree.getSequence(next.id)];
+    while (next.id != null) {
+      sequence = [...tree.getSequence(next.id)]
       node = sequence.slice(-1)[0]
       if (node.children.length > 0) {
         currents[node.id] = node.children.slice(chIdx[1])[0].id
         next = tree.navigate(node.id, 1, currents)
-      } else { break }
+      } else {
+        break
+      }
     }
   }
 

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1535,15 +1535,68 @@ class Sabaki extends EventEmitter {
     this.setCurrentTreePosition(tree, node.id)
   }
 
-  goToSiblingVariation(step) {
-    let {gameTrees, gameIndex, treePosition} = this.state
-    let tree = gameTrees[gameIndex]
-    let section = [...tree.getSection(tree.getLevel(treePosition))]
-    let index = section.findIndex(node => node.id === treePosition)
-    let newIndex =
-      (((step + index) % section.length) + section.length) % section.length
+  // goToSiblingVariation(step) {
+  //   let {gameTrees, gameIndex, treePosition} = this.state
+  //   let tree = gameTrees[gameIndex]
+  //   let section = [...tree.getSection(tree.getLevel(treePosition))]
+  //   let index = section.findIndex(node => node.id === treePosition)
+  //   let newIndex =
+  //     (((step + index) % section.length) + section.length) % section.length
 
-    this.setCurrentTreePosition(tree, section[newIndex].id)
+  //   this.setCurrentTreePosition(tree, section[newIndex].id)
+  // }
+
+  goToSiblingVariation(step) {
+      // redirects gameCurrents[gameIndex] to a new stream
+      let {gameTrees, gameIndex, gameCurrents, treePosition} = this.state
+      let tree = gameTrees[gameIndex]
+      let currents = gameCurrents[gameIndex]
+
+      let chIdx = [-1, 0] // for + changes
+      if (step < 0) {
+          chIdx = [0, -1] // for - changes
+      }
+
+      // find the lowest fork node which does not point to the last child
+      let sequence = [...tree.getSequence(treePosition)]
+      let node = sequence.slice(-1)[0]
+      let next = tree.navigate(node.id, 1, currents)
+      if (next == null) return
+      let lowestFork = node
+      while (next != null) { //not at a leaf
+          // console.log('node ID: %d; next ID: %d',node.id,next.id)
+          // for (let kk=0; kk < node.children.length ; kk++) {
+          //     console.log('child[%d].id: %d',kk,node.children[kk].id)
+          // }
+          if (next.id != node.children.slice(chIdx[0])[0].id) {
+          //    console.log('found a fork at %d', node.id)
+              lowestFork = node;
+          }
+          sequence = [...tree.getSequence(next.id)];
+          node = sequence.slice(-1)[0]
+          next = tree.navigate(node.id, 1, currents)
+      }
+      // console.log('Lowest fork id: %d',lowestFork.id)
+      // increment the currents for the lowest fork node
+      next = tree.navigate(lowestFork.id, 1, currents)
+      let idx = lowestFork.children.findIndex(ch => ch.id == next.id)
+      //console.log('Current child index: %d',idx)
+      let ch_len = lowestFork.children.length
+      idx = (((idx + step) % ch_len) + ch_len) % ch_len // force idx >= 0 :eyeroll:
+      // console.log('idx = %d',idx)
+      currents[lowestFork.id] = lowestFork.children[idx].id
+
+      next = tree.navigate(lowestFork.id, 1, currents) //using new currents
+
+      // then zero the downstream currents.
+      while (next.id != null) { //not at a leaf
+          sequence = [...tree.getSequence(next.id)];
+          node = sequence.slice(-1)[0]
+          if (node.children.length > 0) {
+              currents[node.id] = node.children.slice(chIdx[1])[0].id
+              next = tree.navigate(node.id, 1, currents)
+          } else { break }
+      }
   }
 
   goToMainVariation() {

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1564,26 +1564,19 @@ class Sabaki extends EventEmitter {
       if (next == null) return
       let lowestFork = node
       while (next != null) { //not at a leaf
-          // console.log('node ID: %d; next ID: %d',node.id,next.id)
-          // for (let kk=0; kk < node.children.length ; kk++) {
-          //     console.log('child[%d].id: %d',kk,node.children[kk].id)
-          // }
           if (next.id != node.children.slice(chIdx[0])[0].id) {
-          //    console.log('found a fork at %d', node.id)
               lowestFork = node;
           }
           sequence = [...tree.getSequence(next.id)];
           node = sequence.slice(-1)[0]
           next = tree.navigate(node.id, 1, currents)
       }
-      // console.log('Lowest fork id: %d',lowestFork.id)
+
       // increment the currents for the lowest fork node
       next = tree.navigate(lowestFork.id, 1, currents)
       let idx = lowestFork.children.findIndex(ch => ch.id == next.id)
-      //console.log('Current child index: %d',idx)
       let ch_len = lowestFork.children.length
       idx = (((idx + step) % ch_len) + ch_len) % ch_len // force idx >= 0 :eyeroll:
-      // console.log('idx = %d',idx)
       currents[lowestFork.id] = lowestFork.children[idx].id
 
       next = tree.navigate(lowestFork.id, 1, currents) //using new currents


### PR DESCRIPTION
For your consideration, here is an implementation of [Issue 773](https://github.com/SabakiHQ/Sabaki/issues/773).

Starting from the present node, this finds downstream forks and cycles through the possible variations by altering the `gameCurrents` array.  For myself, I prefer to have these new function calls bound to `Left` and `Right`, but in the interest of not surprising anyone, I bound these to `Shift+Left` and `Shift+Right`.

The function name is a bit jarring.  It doesn't act like a `goTo...`, so I didn't name it as such.