### PR TITLE
Engine layout

### DIFF
--- a/src/components/sidebars/PeerList.js
+++ b/src/components/sidebars/PeerList.js
@@ -24,13 +24,6 @@ class EnginePeerListItem extends Component {
       })
     }
 
-    this.isClickable = evt => {
-      let cursor = window
-        .getComputedStyle(evt.target, null)
-        .getPropertyValue('cursor')
-      return cursor == 'pointer'
-    }
-
     this.handleClick = evt => {
       let {syncer, onClick = () => {}} = this.props
       onClick({syncer})
@@ -42,17 +35,13 @@ class EnginePeerListItem extends Component {
     }
 
     this.handleBlackPlayerButtonClick = evt => {
-      if (this.isClickable(evt)) {
-        let {syncer, onPlayerClick = () => {}} = this.props
-        onPlayerClick({syncer}, 'black')
-      }
+      let {syncer, onPlayerClick = () => {}} = this.props
+      onPlayerClick({syncer}, 'black')
     }
 
     this.handleWhitePlayerButtonClick = evt => {
-      if (this.isClickable(evt)) {
-        let {syncer, onPlayerClick = () => {}} = this.props
-        onPlayerClick({syncer}, 'white')
-      }
+      let {syncer, onPlayerClick = () => {}} = this.props
+      onPlayerClick({syncer}, 'white')
     }
   }
 

--- a/src/components/sidebars/PeerList.js
+++ b/src/components/sidebars/PeerList.js
@@ -24,6 +24,13 @@ class EnginePeerListItem extends Component {
       })
     }
 
+    this.isClickable = evt => {
+      let cursor = window
+        .getComputedStyle(evt.target, null)
+        .getPropertyValue('cursor')
+      return cursor == 'pointer'
+    }
+
     this.handleClick = evt => {
       let {syncer, onClick = () => {}} = this.props
       onClick({syncer})
@@ -32,6 +39,20 @@ class EnginePeerListItem extends Component {
     this.handleContextMenu = evt => {
       let {syncer, onContextMenu = () => {}} = this.props
       onContextMenu(evt, {syncer})
+    }
+
+    this.handleBlackPlayerButtonClick = evt => {
+      if (this.isClickable(evt)) {
+        let {syncer, onPlayerClick = () => {}} = this.props
+        onPlayerClick({syncer}, 'black')
+      }
+    }
+
+    this.handleWhitePlayerButtonClick = evt => {
+      if (this.isClickable(evt)) {
+        let {syncer, onPlayerClick = () => {}} = this.props
+        onPlayerClick({syncer}, 'white')
+      }
     }
   }
 
@@ -94,35 +115,35 @@ class EnginePeerListItem extends Component {
           })
         ),
 
-      blackPlayer &&
-        h(
-          'div',
-          {
-            key: 'player_1',
-            class: 'icon player',
-            title: t('Plays as Black')
-          },
-          h('img', {
-            height: 14,
-            src: './img/ui/black.svg',
-            alt: t('Plays as Black')
-          })
-        ),
+      h(
+        'div',
+        {
+          key: 'player_1',
+          class: 'icon player' + (blackPlayer ? '' : ' inactive'),
+          title: t('Plays as Black'),
+          onClick: this.handleBlackPlayerButtonClick
+        },
+        h('img', {
+          height: 14,
+          src: './img/ui/black.svg',
+          alt: t('Plays as Black')
+        })
+      ),
 
-      whitePlayer &&
-        h(
-          'div',
-          {
-            key: 'player_-1',
-            class: 'icon player',
-            title: t('Plays as White')
-          },
-          h('img', {
-            height: 14,
-            src: './img/ui/white.svg',
-            alt: t('Plays as White')
-          })
-        )
+      h(
+        'div',
+        {
+          key: 'player_-1',
+          class: 'icon player' + (whitePlayer ? '' : ' inactive'),
+          title: t('Plays as White'),
+          onClick: this.handleWhitePlayerButtonClick
+        },
+        h('img', {
+          height: 14,
+          src: './img/ui/white.svg',
+          alt: t('Plays as White')
+        })
+      )
     )
   }
 }
@@ -144,6 +165,13 @@ export class EnginePeerList extends Component {
         x: evt.clientX,
         y: evt.clientY
       })
+    }
+
+    this.handleEnginePlayerClick = ({syncer}, player) => {
+      let {onEngineSelect = () => {}} = this.props
+      onEngineSelect({syncer})
+
+      sabaki.toggleEnginePlayer(syncer.id, player)
     }
 
     this.handleAttachEngineButtonClick = evt => {
@@ -206,7 +234,8 @@ export class EnginePeerList extends Component {
             whitePlayer: syncer.id === whiteEngineSyncerId,
 
             onClick: this.handleEngineClick,
-            onContextMenu: this.handleEngineContextMenu
+            onContextMenu: this.handleEngineContextMenu,
+            onPlayerClick: this.handleEnginePlayerClick
           })
         )
       )

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -2794,6 +2794,29 @@ class Sabaki extends EventEmitter {
     )
   }
 
+  toggleEnginePlayer(syncerId, player) {
+    let syncer = this.state.attachedEngineSyncers.find(
+      syncer => syncer.id === syncerId
+    )
+    if (syncer == null) return
+    switch (player) {
+      case 'black':
+      case 'player_1':
+        this.setState(state => ({
+          blackEngineSyncerId:
+            state.blackEngineSyncerId === syncerId ? null : syncerId
+        }))
+        break
+      case 'white':
+      case 'player_-1':
+        this.setState(state => ({
+          whiteEngineSyncerId:
+            state.whiteEngineSyncerId === syncerId ? null : syncerId
+        }))
+        break
+    }
+  }
+
   openEngineActionMenu(syncerId, {x, y} = {}) {
     let t = i18n.context('menu.engineAction')
     let syncer = this.state.attachedEngineSyncers.find(

--- a/style/index.css
+++ b/style/index.css
@@ -1362,6 +1362,12 @@ header {
   }
   .engine-peer-list .item .icon.player {
     filter: none;
+    cursor: pointer; /* enables onclick */
+/*  cursor: default; */ /* 0.52.0 onclick (nothing) behavior */
+  }
+  .engine-peer-list .item .icon.inactive {
+      opacity: .3;
+/*       display: none; */ /* 0.52.0 layout */
   }
   .engine-peer-list .item .text-spinner {
     width: 1.5em;

--- a/style/index.css
+++ b/style/index.css
@@ -1362,12 +1362,10 @@ header {
   }
   .engine-peer-list .item .icon.player {
     filter: none;
-    cursor: pointer; /* enables onclick */
-/*  cursor: default; */ /* 0.52.0 onclick (nothing) behavior */
+    cursor: pointer;
   }
   .engine-peer-list .item .icon.inactive {
       opacity: .3;
-/*       display: none; */ /* 0.52.0 layout */
   }
   .engine-peer-list .item .text-spinner {
     width: 1.5em;


### PR DESCRIPTION
Demo of layout part of #848

This keeps engine player icon visible, and makes them clickable to toggle player role. Displaying whether an engine plays black or white (or none of them) is controlled by CSS (here opacity). 
Setting CSS to `display: none` would restore the old layout, though icons are still clickable.