### PR TITLE
Upgrade to Shudan 1.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,8 +122,8 @@
     "prettier": "1.19.1",
     "react": "^16.13.1",
     "tmp": "^0.1.0",
-    "webpack": "^4.42.1",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^5.74.0",
+    "webpack-cli": "^4.10.0"
   },
   "scripts": {
     "test": "mocha --require esm",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",
     "@sabaki/sgf": "^3.4.7",
-    "@sabaki/shudan": "^1.5.4",
+    "@sabaki/shudan": "^1.7.1",
     "argv-split": "^2.0.1",
     "classnames": "^2.2.6",
     "dolm": "^0.7.3-beta",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = (env, argv) => ({
     path: __dirname
   },
 
-  devtool: argv.mode === 'production' ? false : 'cheap-module-eval-source-map',
+  devtool: argv.mode === 'production' ? false : 'eval-cheap-module-source-map',
   target: 'electron-renderer',
 
   node: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,10 +21,6 @@ module.exports = (env, argv) => ({
         argv.mode === 'production'
           ? path.join(__dirname, 'node_modules/preact/dist/preact.min.js')
           : 'preact',
-      preact:
-        argv.mode === 'production'
-          ? path.join(__dirname, 'node_modules/preact/dist/preact.min.js')
-          : 'preact',
       'prop-types': path.join(__dirname, 'src/modules/shims/prop-types.js')
     }
   },


### PR DESCRIPTION
This required an upgrade from Webpack 4 to Webpack 5 because Shudan 1.7.0 makes use of the nullish coalescing operator '??' which Webpack 4 fails to parse. Luckily, this was a pretty painless migration.

Closes #882.