### PR TITLE
Remove react from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "mocha": "^7.1.1",
     "onchange": "^6.1.0",
     "prettier": "1.19.1",
-    "react": "^16.13.1",
     "tmp": "^0.2.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"


### PR DESCRIPTION
I don't understand why it was here in the first place, it gets
aliased to preact anyway. I've tested and diffed the final output
with/without in both dev and prod modes and can't find any
difference at all. So for the sake of clarity and shutting up
dependabot, I'm going to remove react from devDependencies
until I figure out why it was here in the first place.

@yishn if there's a good reason to keep it please let me know :)
I'm still pretty naive when it comes to the npm ecosystem.