### PR TITLE
Fix react-markdown component names

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "natsort": "^2.0.2",
     "pikaday": "^1.8.0",
     "preact": "^10.4.0",
-    "react-markdown": "4.0.0",
+    "react-markdown": "^8.0.3",
     "recursive-copy": "^2.0.10",
     "remark-breaks": "^3.0.2",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "natsort": "^2.0.2",
     "pikaday": "^1.8.0",
     "preact": "^10.4.0",
-    "react-markdown": "^3.6.0",
+    "react-markdown": "4.0.0",
     "recursive-copy": "^2.0.10",
     "remark-breaks": "^3.0.2",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "natsort": "^2.0.2",
     "pikaday": "^1.8.0",
     "preact": "^10.4.0",
-    "react-markdown": "^8.0.3",
+    "react-markdown": "^3.6.0",
     "recursive-copy": "^2.0.10",
     "remark-breaks": "^3.0.2",
     "rimraf": "^3.0.2",

--- a/src/components/MarkdownContentDisplay.js
+++ b/src/components/MarkdownContentDisplay.js
@@ -18,13 +18,11 @@ function typographer(children) {
 
 function htmlify(children) {
   return toChildArray(children).map(child => {
-    let text = child.props.children
-
-    if (typeof text !== 'string') return child
+    if (typeof child !== 'string') return child
 
     return h(ContentDisplay, {
       tag: 'span',
-      content: typographer(text)
+      content: typographer(child)
     })
   })
 }
@@ -68,20 +66,23 @@ function Html({isBlock, value}) {
 class MarkdownContentDisplay extends Component {
   render({source}) {
     return h(ReactMarkdown, {
-      source,
-      plugins: [breaks],
-      renderers: {
-        paragraph: Paragraph,
-        emphasis: Emphasis,
+      children: source,
+      remarkPlugins: [breaks],
+      components: {
+        p: Paragraph,
+        em: Emphasis,
         strong: Strong,
-        delete: Delete,
-        link: Link,
-        image: Image,
-        linkReference: Link,
-        imageReference: Image,
+        del: Delete,
+        a: Link,
+        img: Image,
         table: Table,
-        listItem: ListItem,
-        heading: Heading,
+        li: ListItem,
+        h1: Heading,
+        h2: Heading,
+        h3: Heading,
+        h4: Heading,
+        h5: Heading,
+        h6: Heading,
         code: Paragraph,
         html: Html
       }

--- a/src/components/MarkdownContentDisplay.js
+++ b/src/components/MarkdownContentDisplay.js
@@ -66,9 +66,9 @@ function Html({isBlock, value}) {
 class MarkdownContentDisplay extends Component {
   render({source}) {
     return h(ReactMarkdown, {
-      children: source,
-      remarkPlugins: [breaks],
-      components: {
+      source,
+      plugins: [breaks],
+      renderers: {
         paragraph: Paragraph,
         emphasis: Emphasis,
         strong: Strong,

--- a/src/components/MarkdownContentDisplay.js
+++ b/src/components/MarkdownContentDisplay.js
@@ -18,11 +18,13 @@ function typographer(children) {
 
 function htmlify(children) {
   return toChildArray(children).map(child => {
-    if (typeof child !== 'string') return child
+    let text = child.props.children
+
+    if (typeof text !== 'string') return child
 
     return h(ContentDisplay, {
       tag: 'span',
-      content: typographer(child)
+      content: typographer(text)
     })
   })
 }


### PR DESCRIPTION
The API change in react-markdown 6.0.0 was a little deeper than I though, the renderers need to be converted to "components" according to their HTML entity types rather than their abstract markdown names.

Fixes #898.