### PR TITLE
Perform theme copy natively without recursive-copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "pikaday": "^1.8.0",
     "preact": "^10.4.0",
     "react-markdown": "^8.0.3",
-    "recursive-copy": "^2.0.10",
     "remark-breaks": "^3.0.2",
     "rimraf": "^3.0.2",
     "uuid": "^7.0.3",

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -4,7 +4,6 @@ import * as remote from '@electron/remote'
 import {h, Component} from 'preact'
 import classNames from 'classnames'
 import {join} from 'path'
-import copy from 'recursive-copy'
 import rimraf from 'rimraf'
 import {v4 as uuid} from 'uuid'
 import natsort from 'natsort'
@@ -12,7 +11,11 @@ import natsort from 'natsort'
 import i18n from '../../i18n.js'
 import sabaki from '../../modules/sabaki.js'
 import {showOpenDialog, showMessageBox} from '../../modules/dialog.js'
-import {noop, isWritableDirectory} from '../../modules/helper.js'
+import {
+  copyFolderSync,
+  noop,
+  isWritableDirectory
+} from '../../modules/helper.js'
 import * as gtplogger from '../../modules/gtplogger.js'
 import Drawer from './Drawer.js'
 
@@ -449,12 +452,14 @@ class ThemesTab extends Component {
 
       let id = uuid()
 
-      copy(result[0], join(setting.themesDirectory, id), err => {
-        if (err) return showMessageBox(t('Installation failed.'), 'error')
+      try {
+        copyFolderSync(result[0], join(setting.themesDirectory, id))
 
         setting.loadThemes()
         setting.set('theme.current', id)
-      })
+      } catch (err) {
+        return showMessageBox(t('Installation failed.'), 'error')
+      }
     }
 
     setting.events.on(sabaki.window.id, 'change', ({key, value}) => {

--- a/src/modules/helper.js
+++ b/src/modules/helper.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import {join} from 'path'
 
 let id = 0
 
@@ -140,6 +141,17 @@ export function isWritableDirectory(path) {
     // Path doesn't exist
     return false
   }
+}
+
+export function copyFolderSync(from, to) {
+  fs.mkdirSync(to)
+  fs.readdirSync(from).forEach(element => {
+    if (fs.lstatSync(join(from, element)).isFile()) {
+      fs.copyFileSync(join(from, element), join(to, element))
+    } else {
+      copyFolderSync(join(from, element), join(to, element))
+    }
+  })
 }
 
 export function getScore(board, areaMap, {komi = 0, handicap = 0} = {}) {


### PR DESCRIPTION
There's some sort of issue with recursive-copy's interaction with Electron's ASAR-patched fs module. This sidesteps the entire issue by just reimplementing the ASAR copy-extraction using native `fs` instead of involving third-party libraries.

This is now sync instead of async but I don't think this will matter.

Fixes #897.