### PR TITLE
Allows users to edit influence boxes when in Estimate/Scoring mode.

### DIFF
--- a/e2e/scoring-overrides.spec.js
+++ b/e2e/scoring-overrides.spec.js
@@ -1,0 +1,90 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// Manual territory overrides in scoring mode (state.estimateOverrides): clicking
+// an empty point cycles its area value one step per click, and toggling any
+// stone's life/death clears all overrides so a stale one can't drift against the
+// recomputed area map (the bug from the PR's 2024 review). Assertions check both
+// the state map and the rendered Shudan paint, so a broken render path can't hide
+// behind correct state.
+
+const SGF = '(;GM[1]FF[4]SZ[9];B[cc];W[gg])'
+
+function overrides(page) {
+  return page.evaluate(() => window.__sabaki.state.estimateOverrides)
+}
+
+// The territory paint Shudan renders for a vertex: 1 (black), -1 (white), or 0
+// (none). Scoring mode feeds the areaMap in as the paintMap, so this reflects
+// the override applied on top of the estimate.
+function paintAt(page, [x, y]) {
+  return page.evaluate(
+    ([vx, vy]) => {
+      let el = document.querySelector(
+        `.shudan-vertex[data-x="${vx}"][data-y="${vy}"]`,
+      )
+      if (el == null) return null
+      if (el.classList.contains('shudan-paint_1')) return 1
+      if (el.classList.contains('shudan-paint_-1')) return -1
+      return 0
+    },
+    [x, y],
+  )
+}
+
+async function click(page, vertex) {
+  await page.evaluate((v) => window.__sabaki.clickVertex(v), vertex)
+  await waitForRender(page)
+}
+
+test.describe('scoring overrides', () => {
+  test.beforeEach(async ({page}) => {
+    await loadSgfStringAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+    await page.evaluate(() => window.__sabaki.setMode('scoring'))
+    await page.waitForFunction(() => window.__sabaki.state.mode === 'scoring')
+    await waitForRender(page)
+  })
+
+  test('clicking cycles the territory in state and in the rendered paint', async ({
+    page,
+  }) => {
+    let vertex = [4, 4]
+    expect(await overrides(page)).toEqual({})
+    let base = await paintAt(page, vertex)
+
+    await click(page, vertex)
+    let first = await paintAt(page, vertex)
+    expect(await overrides(page)).toHaveProperty('4,4', 1)
+    expect(first).not.toBe(base) // the paint actually changed in the DOM
+
+    await click(page, vertex)
+    let second = await paintAt(page, vertex)
+    expect(await overrides(page)).toHaveProperty('4,4', 2)
+
+    // Across the cycle the point renders all three distinct area states.
+    expect(new Set([base, first, second]).size).toBe(3)
+
+    // A third click completes the cycle: the override is dropped (not left as a
+    // count of 3), and the paint returns to the estimate.
+    await click(page, vertex)
+    expect(await overrides(page)).toEqual({})
+    expect(await paintAt(page, vertex)).toBe(base)
+  })
+
+  test('toggling a stone alive/dead clears overrides', async ({page}) => {
+    let vertex = [4, 4]
+    let base = await paintAt(page, vertex)
+
+    await click(page, vertex)
+    expect(Object.keys(await overrides(page))).toHaveLength(1)
+    expect(await paintAt(page, vertex)).not.toBe(base) // override is showing
+
+    // Clicking a stone routes to the life/death toggle, which clears overrides.
+    // (The toggle also recomputes the area map, so we assert on the cleared
+    // state rather than the post-toggle paint, which no longer has a fixed base.)
+    await click(page, [2, 2])
+    expect(await overrides(page)).toEqual({})
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -44,5 +44,10 @@ module.exports = defineConfig({
       testMatch: /settings-cache\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'scoring-overrides',
+      testMatch: /scoring-overrides\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -331,6 +331,13 @@ class App extends Component {
         state.mode === 'estimator'
           ? influence.map(scoreBoard.signMap, {discrete: true})
           : influence.areaMap(scoreBoard.signMap)
+
+      for (let vertex in state.estimateOverrides) {
+        let clickCount = state.estimateOverrides[vertex]
+        let coord = vertex.split('x')
+        let val = areaMap[coord[0]][coord[1]] + 1 + clickCount
+        areaMap[coord[0]][coord[1]] = (val % 3) - 1
+      }
     }
 
     state = {...state, ...inferredState, scoreBoard, areaMap}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -21,6 +21,7 @@ import sabaki from '../modules/sabaki.js'
 import * as gametree from '../modules/gametree.js'
 import * as gtplogger from '../modules/gtplogger.js'
 import * as helper from '../modules/helper.js'
+import * as utils from '../modules/utils.js'
 
 if (process.env.SABAKI_E2E) window.__sabaki = sabaki
 
@@ -332,11 +333,12 @@ class App extends Component {
           ? influence.map(scoreBoard.signMap, {discrete: true})
           : influence.areaMap(scoreBoard.signMap)
 
-      for (let vertex in state.estimateOverrides) {
-        let clickCount = state.estimateOverrides[vertex]
-        let coord = vertex.split('x')
-        let val = areaMap[coord[0]][coord[1]] + 1 + clickCount
-        areaMap[coord[0]][coord[1]] = (val % 3) - 1
+      for (let key in state.estimateOverrides) {
+        let [x, y] = key.split(',').map(Number)
+        areaMap[y][x] = utils.cycleAreaValue(
+          areaMap[y][x],
+          state.estimateOverrides[key],
+        )
       }
     }
 

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1088,14 +1088,18 @@ class Sabaki extends EventEmitter {
       if (button !== 0) return
 
       if (board.get(vertex) === 0) {
-        let {estimateOverrides} = this.state
+        // Clicking an empty point overrides its estimated territory, cycling it
+        // one step (neutral -> black -> white) per click. The stored value is
+        // the step offset in [1, 2]; a third click completes the cycle and
+        // drops the override entirely, so the map only ever holds real overrides.
+        let [x, y] = vertex
+        let key = x + ',' + y
+        let {[key]: current = 0, ...rest} = this.state.estimateOverrides
+        let next = (current + 1) % 3
 
-        let clickCount = estimateOverrides[vertex[1] + 'x' + vertex[0]]
-        clickCount = !clickCount ? 1 : clickCount + 1
-
-        estimateOverrides[vertex[1] + 'x' + vertex[0]] = clickCount
-
-        this.setState({estimateOverrides})
+        this.setState({
+          estimateOverrides: next === 0 ? rest : {...rest, [key]: next},
+        })
         return
       }
 
@@ -1114,7 +1118,10 @@ class Sabaki extends EventEmitter {
         )
       }
 
-      this.setState({deadStones})
+      // Toggling life/death recomputes the area map, so any manual overrides no
+      // longer line up with it -- clear them rather than let them drift onto
+      // points the user never clicked.
+      this.setState({deadStones, estimateOverrides: {}})
     } else if (this.state.mode === 'find') {
       if (button !== 0) return
 

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -65,6 +65,7 @@ class Sabaki extends EventEmitter {
       findVertex: null,
       deadStones: [],
       blockedGuesses: [],
+      estimateOverrides: {},
 
       // Goban
 
@@ -345,6 +346,8 @@ class Sabaki extends EventEmitter {
 
   setMode(mode) {
     if (this.state.mode === mode) return
+
+    this.setState({estimateOverrides: {}})
 
     let stateChange = {mode}
 
@@ -1082,7 +1085,19 @@ class Sabaki extends EventEmitter {
         this.editVertexData = null
       }
     } else if (['scoring', 'estimator'].includes(this.state.mode)) {
-      if (button !== 0 || board.get(vertex) === 0) return
+      if (button !== 0) return
+
+      if (board.get(vertex) === 0) {
+        let {estimateOverrides} = this.state
+
+        let clickCount = estimateOverrides[vertex[1] + 'x' + vertex[0]]
+        clickCount = !clickCount ? 1 : clickCount + 1
+
+        estimateOverrides[vertex[1] + 'x' + vertex[0]] = clickCount
+
+        this.setState({estimateOverrides})
+        return
+      }
 
       let {mode, deadStones} = this.state
       let dead = deadStones.some((v) => helper.vertexEquals(v, vertex))

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -119,3 +119,11 @@ export function getScore(board, areaMap, {komi = 0, handicap = 0} = {}) {
 
   return score
 }
+
+// Advance an area-map value -- -1 (white) / 0 (neutral) / 1 (black) -- by
+// `steps` positions through the neutral -> black -> white cycle. Backs the
+// manual territory overrides in scoring/estimator mode, where each overridden
+// point stores how many steps it's been nudged from the estimate (1 or 2).
+export function cycleAreaValue(value, steps) {
+  return ((value + 1 + steps) % 3) - 1
+}

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -1,0 +1,27 @@
+import assert from 'assert'
+
+import {cycleAreaValue} from '../src/modules/utils.js'
+
+// cycleAreaValue backs the manual territory overrides in scoring/estimator mode.
+// Area values are -1 (white) / 0 (neutral) / 1 (black), and `steps` advances a
+// point that many positions through neutral -> black -> white, relative to
+// whatever the estimate currently shows there.
+describe('cycleAreaValue', () => {
+  it('cycles a neutral point through black, white, back to neutral', () => {
+    assert.strictEqual(cycleAreaValue(0, 1), 1)
+    assert.strictEqual(cycleAreaValue(0, 2), -1)
+    assert.strictEqual(cycleAreaValue(0, 3), 0)
+  })
+
+  it('advances relative to the current estimate, not from neutral', () => {
+    assert.strictEqual(cycleAreaValue(1, 1), -1) // black estimate -> white
+    assert.strictEqual(cycleAreaValue(-1, 1), 0) // white estimate -> neutral
+  })
+
+  it('wraps every three steps back to the estimate', () => {
+    for (let base of [-1, 0, 1]) {
+      assert.strictEqual(cycleAreaValue(base, 3), base)
+      assert.strictEqual(cycleAreaValue(base, 6), base)
+    }
+  })
+})


### PR DESCRIPTION
When in scoring or estimation mode, we now track any vertexes that the user clicks
via the state.estimateOverrides property.  In our app render method, we then
override the area influence map with these clicks.  Clicks cycle through black/white/
empty.  A +1, -1 is used in the equations to reflect the fact that black/white/empty values
in the influence map are tracked via values of [-1,0,1].