### PR TITLE
Add a setting for randomly rotating boards on file load Issue #960

### DIFF
--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -306,6 +306,10 @@ class GeneralTab extends Component {
         h(PreferencesItem, {
           id: 'view.winrategraph_invert',
           text: t('Invert winrate graph')
+        }),
+        h(PreferencesItem, {
+          id: 'file.loadrandomizedboard',
+          text: t('Randomized board rotation on load')
         })
       )
     )

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -514,6 +514,13 @@ class Sabaki extends EventEmitter {
       if (setting.get('game.goto_end_after_loading')) {
         this.goToEnd()
       }
+
+      //This is the rotation setting that Jiaying put in
+      if (setting.get('file.loadrandomizedboard')) {
+        const rotations = ['', 'r', 'rr', 'rrr']
+        let random = Math.floor(Math.random() * rotations.length)
+        this.pushBoardTransformation(rotations[random])
+      }
     }
 
     this.setBusy(false)

--- a/src/setting.js
+++ b/src/setting.js
@@ -202,7 +202,7 @@ let defaults = {
   'view.show_next_moves': true,
   'view.show_siblings': true,
   'view.show_winrategraph': true,
-  'file.loadrandomizedboard': true,
+  'file.loadrandomizedboard': false,
   'view.sidebar_width': 200,
   'view.sidebar_minwidth': 100,
   'view.winrategraph_blunderthreshold': 5,

--- a/src/setting.js
+++ b/src/setting.js
@@ -202,6 +202,7 @@ let defaults = {
   'view.show_next_moves': true,
   'view.show_siblings': true,
   'view.show_winrategraph': true,
+  'file.loadrandomizedboard': true,
   'view.sidebar_width': 200,
   'view.sidebar_minwidth': 100,
   'view.winrategraph_blunderthreshold': 5,


### PR DESCRIPTION
- A new setting in Menu > Sabaki > Preferences called "Randomized board rotation on load"
- If checked, on file load the board will be rotated 0, 90, 180, 270 degrees