### PR TITLE
Make helptext for adding engines clearer for nontechnical users

### DIFF
--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -666,7 +666,9 @@ class EngineItem extends Component {
         ),
         h('input', {
           type: 'text',
-          placeholder: t('Path'),
+          placeholder: t(
+            'Path (e.g., /path/to/engine or C:\\path\\to\\engine.exe)'
+          ),
           value: path || '',
           name: 'path',
           onChange: this.handleChange
@@ -677,7 +679,9 @@ class EngineItem extends Component {
         {},
         h('input', {
           type: 'text',
-          placeholder: t('No arguments'),
+          placeholder: t(
+            'Optional arguments (e.g., -param1 value1 -param2 value2)'
+          ),
           value: args || '',
           name: 'args',
           onChange: this.handleChange


### PR DESCRIPTION
The helptext for adding a new engine had room for improvement to allow for nontechnical users to better understand how to add an engine to Sabaki.

This was brought up in #756 when the author had trouble adding an engine to Sabaki. This PR hopes to clarify confusion from users who may just be trying to follow command line instructions from Engine documentation and not know much about command lines.

