### PR TITLE
Add Playwright E2E test suite with CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: 
+on:
   push:
     branches: [master]
   pull_request:
@@ -10,15 +10,60 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
-    - name: npm install, build, and test
-      run: |
-        npm install
-        npm run format-check
-        npm run build
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm install
+      - name: Check formatting
+        run: npm run format-check
+      - name: Build and test
+        run: |
+          npm run build
+          npm test
+        env:
+          CI: true
+      - name: Build webpack dev bundle
+        run: npx webpack --mode development
+      - name: Upload dev bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: webpack-dev-bundle
+          path: bundle.js
+          retention-days: 1
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+      - name: Install dependencies
+        run: npm install
+      - name: Download dev bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: webpack-dev-bundle
+      - name: Install Electron system dependencies
+        run: npx playwright install-deps chromium
+      - name: Run E2E tests
+        run: |
+          xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- \
+            npx playwright test
+        env:
+          CI: true
+          SABAKI_E2E: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ bundle.js.map
 
 *.pdn
 *.vbs
+
+playwright-report/
+test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@ First of all, thank you for taking the time to contribute to Sabaki!
 - Run prettier to make sure your code adheres to the coding style standards. You
   can use the command `npm run format` to format all the files.
 - Avoid platform-dependent code.
-- Create mocha tests if possible and applicable.
+- Create mocha unit tests if possible and applicable. For UI or integration
+  behavior, add Playwright E2E tests in the `e2e/` directory.
 - Document new code in the documentation if applicable.
 - Note the issue number in your pull request.
 

--- a/docs/guides/building-tests.md
+++ b/docs/guides/building-tests.md
@@ -56,9 +56,54 @@ $ npm run format
 
 ## Tests
 
+### Unit Tests
+
 Make sure you have the master branch checked out since there are no test in the
-web branch. To run the (currently very limited) unit tests, use:
+web branch. To run the unit tests, use:
 
 ```
 $ npm test
 ```
+
+### E2E Tests
+
+Sabaki includes Playwright-based end-to-end tests that launch the full Electron
+application. The test files live in the `e2e/` directory:
+
+```
+e2e/
+├── fixtures/
+│   └── electron-app.js   # Shared Playwright fixture (launches Sabaki)
+├── helpers.js             # Shared helper functions
+├── smoke.spec.js          # App launch & basic rendering
+├── renderer.spec.js       # UI interactions, SGF loading, navigation
+└── engine.spec.js         # GTP engine attach/detach & gameplay
+```
+
+**Running E2E tests:**
+
+```
+$ npm run test:e2e              # Build webpack bundle + run all suites
+$ npm run test:e2e:smoke        # Build + run smoke suite only
+$ npm run test:e2e:headed       # Build + run with visible window (Linux only)
+$ npx playwright test --project=renderer   # Run one suite (skip rebuild)
+```
+
+**Platform notes:**
+
+- **Linux:** Tests run in a virtual framebuffer (`xvfb-run`) by default. Use
+  `npm run test:e2e:headed` to bypass xvfb and see the actual Electron window
+  for debugging.
+- **macOS / Windows:** There is no virtual framebuffer — the Electron window
+  will briefly flash on screen during test runs. The `:headed` flag has no
+  effect on these platforms.
+
+**Writing new tests:**
+
+- Create a `*.spec.js` file in `e2e/` and add a matching project entry in
+  `playwright.config.js`.
+- Import the `test` object from `e2e/fixtures/electron-app.js` — this provides
+  `electronApp` and `page` fixtures with isolated settings and dialog stubs.
+- Use helpers from `e2e/helpers.js` (`loadSgfAndWait`, `getTreeDepth`,
+  `attachAndWaitForEngines`, etc.) for common operations.
+- Access app state via `window.__sabaki` in `page.evaluate()` calls.

--- a/e2e/engine.spec.js
+++ b/e2e/engine.spec.js
@@ -1,0 +1,163 @@
+const {expect} = require('@playwright/test')
+const path = require('path')
+const {test} = require('./fixtures/electron-app')
+const {
+  loadSgfAndWait,
+  getTreeDepth,
+  attachAndWaitForEngines,
+  detachAndWait,
+  enginePath,
+} = require('./helpers')
+
+test.describe('GTP Engine Integration Tests', () => {
+  test('attach and start engine', async ({page}) => {
+    const syncerInfo = await page.evaluate((ePath) => {
+      const syncers = window.__sabaki.attachEngines([
+        {name: 'ResignEngine', path: process.execPath, args: ePath},
+      ])
+      return syncers.map((s) => ({id: s.id, name: s.engine.name}))
+    }, enginePath)
+
+    expect(syncerInfo).toHaveLength(1)
+    expect(syncerInfo[0].name).toBe('ResignEngine')
+
+    // Verify it appears in state
+    const attached = await page.evaluate(() => {
+      return window.__sabaki.state.attachedEngineSyncers.map((s) => s.id)
+    })
+    expect(attached).toContain(syncerInfo[0].id)
+
+    // Wait for engine to be started (process is running)
+    await page.waitForFunction(
+      (syncerId) => {
+        const syncer = window.__sabaki.state.attachedEngineSyncers.find(
+          (s) => s.id === syncerId,
+        )
+        return syncer && !syncer._suspended
+      },
+      syncerInfo[0].id,
+      {timeout: 10000},
+    )
+
+    // Clean up
+    await detachAndWait(page, attached)
+  })
+
+  test('detach engine cleanly', async ({page}) => {
+    const syncerIds = await attachAndWaitForEngines(page, [
+      {name: 'ResignEngine', path: process.execPath, args: enginePath},
+    ])
+
+    expect(syncerIds).toHaveLength(1)
+
+    await detachAndWait(page, syncerIds)
+
+    const remaining = await page.evaluate(() => {
+      return window.__sabaki.state.attachedEngineSyncers.length
+    })
+    expect(remaining).toBe(0)
+  })
+
+  test('engine responds to genmove', async ({page}) => {
+    const syncerIds = await attachAndWaitForEngines(page, [
+      {name: 'ResignEngine', path: process.execPath, args: enginePath},
+    ])
+
+    const initialNodeId = await page.evaluate(() => {
+      return window.__sabaki.state.treePosition
+    })
+
+    const result = await page.evaluate(async (syncerId) => {
+      try {
+        const r = await window.__sabaki.generateMove(
+          syncerId,
+          window.__sabaki.state.treePosition,
+        )
+        return r
+          ? {ok: true, treePosition: r.treePosition, resign: r.resign}
+          : {ok: false, reason: 'generateMove returned null'}
+      } catch (e) {
+        return {ok: false, reason: e.message}
+      }
+    }, syncerIds[0])
+
+    expect(result.ok).toBe(true)
+
+    const newNodeId = await page.evaluate(() => {
+      return window.__sabaki.state.treePosition
+    })
+    expect(newNodeId).not.toBe(initialNodeId)
+
+    // Clean up
+    await detachAndWait(page, syncerIds)
+  })
+
+  test('bot-vs-bot game completes', async ({page}) => {
+    const syncerIds = await attachAndWaitForEngines(page, [
+      {name: 'BlackEngine', path: process.execPath, args: enginePath},
+      {name: 'WhiteEngine', path: process.execPath, args: enginePath},
+    ])
+
+    expect(syncerIds).toHaveLength(2)
+
+    // Assign engines to black and white
+    await page.evaluate((ids) => {
+      window.__sabaki.setState({
+        blackEngineSyncerId: ids[0],
+        whiteEngineSyncerId: ids[1],
+      })
+    }, syncerIds)
+
+    // startEngineGame is async and resolves when the game ends (resign
+    // or two consecutive passes), so we can await it directly.
+    const result = await page.evaluate(async () => {
+      try {
+        await window.__sabaki.startEngineGame(
+          window.__sabaki.state.treePosition,
+        )
+        return {ok: true}
+      } catch (e) {
+        return {ok: false, reason: e.message}
+      }
+    })
+
+    expect(result.ok).toBe(true)
+
+    // The resign engine plays 3 moves then resigns, so with 2 engines
+    // we expect at least 3 total moves before one resigns
+    expect(await getTreeDepth(page)).toBeGreaterThanOrEqual(3)
+
+    // Clean up
+    await detachAndWait(page, syncerIds)
+  })
+
+  test('board state sync after loading SGF', async ({page}) => {
+    const sgfPath = path.resolve(__dirname, '..', 'test', 'sgf', 'pro_game.sgf')
+
+    await loadSgfAndWait(page, sgfPath)
+
+    // Navigate to move 5
+    await page.evaluate(() => {
+      for (let i = 0; i < 5; i++) {
+        window.__sabaki.goStep(1)
+      }
+    })
+
+    const positionBeforeEngine = await page.evaluate(() => {
+      return window.__sabaki.state.treePosition
+    })
+
+    const syncerIds = await attachAndWaitForEngines(page, [
+      {name: 'ResignEngine', path: process.execPath, args: enginePath},
+    ])
+
+    // Verify the treePosition hasn't changed from attaching the engine
+    const positionAfterEngine = await page.evaluate(() => {
+      return window.__sabaki.state.treePosition
+    })
+    expect(positionAfterEngine).toBe(positionBeforeEngine)
+
+    // Clean up
+    await detachAndWait(page, syncerIds)
+  })
+})

--- a/e2e/fixtures/electron-app.js
+++ b/e2e/fixtures/electron-app.js
@@ -1,0 +1,118 @@
+const {test: base, _electron: electron} = require('@playwright/test')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
+
+const test = base.extend({
+  electronApp: async ({}, use) => {
+    // Create isolated temp directory for settings
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sabaki-e2e-'))
+
+    // Pre-seed settings to disable animations, sounds, update checks, etc.
+    const settings = {
+      'app.startup_check_updates': false,
+      'app.startup_check_updates_delay': 100000,
+      'app.loadgame_delay': 0,
+      'app.hide_busy_delay': 0,
+      'sound.enable': false,
+      'view.animated_stone_placement': false,
+      'view.fuzzy_stone_placement': false,
+      'gtp.move_delay': 0,
+      'game.goto_end_after_loading': false,
+      'file.show_reload_warning': false,
+      'infooverlay.duration': 0,
+    }
+
+    // app.getPath('userData') returns <userDataDir>/Sabaki when
+    // --user-data-dir is set, so write settings into that subdirectory.
+    const appDataDir = path.join(tmpDir, 'Sabaki')
+    fs.mkdirSync(appDataDir, {recursive: true})
+    fs.mkdirSync(path.join(appDataDir, 'themes'), {recursive: true})
+
+    fs.writeFileSync(
+      path.join(appDataDir, 'settings.json'),
+      JSON.stringify(settings, null, 2),
+    )
+
+    const electronPath = require('electron')
+    const appPath = path.resolve(__dirname, '..', '..')
+
+    // On Linux CI, the chrome-sandbox binary requires setuid root permissions
+    // which aren't available. Disable the sandbox in CI environments.
+    const args = [appPath, `--user-data-dir=${tmpDir}`]
+    if (process.env.CI) {
+      args.push('--no-sandbox')
+    }
+
+    const app = await electron.launch({
+      executablePath: electronPath,
+      args,
+      env: {
+        ...process.env,
+        SABAKI_E2E: '1',
+      },
+    })
+
+    // Stub all dialog functions in the main process to prevent native OS
+    // dialogs from blocking tests. Without these stubs, any dialog call
+    // (save prompt, error box, file picker) would block the process until
+    // manually dismissed.
+    await app.evaluate(({dialog}) => {
+      dialog.showMessageBox = async () => ({response: 1})
+      dialog.showOpenDialog = async () => ({canceled: true, filePaths: []})
+      dialog.showSaveDialog = async () => ({canceled: true})
+      dialog.showErrorBox = (title, content) => {
+        console.error(`[showErrorBox] ${title}\n${content}`)
+      }
+    })
+
+    await use(app)
+
+    // Teardown: use app.exit() to force-quit immediately.
+    // app.quit() triggers beforeunload handlers which set evt.returnValue,
+    // causing CDP "handleJavaScriptDialog" errors in Playwright.
+    // app.exit() skips all lifecycle events and exits the process cleanly.
+    try {
+      await app.evaluate(({app}) => {
+        app.exit(0)
+      })
+    } catch (e) {
+      // App may already be closed
+    }
+
+    try {
+      await app.close()
+    } catch (e) {
+      // App may already be closed
+    }
+
+    // Clean up temp directory
+    try {
+      fs.rmSync(tmpDir, {recursive: true, force: true})
+    } catch (e) {
+      // Best effort cleanup
+    }
+  },
+
+  page: async ({electronApp}, use) => {
+    // Wait for the first window
+    const page =
+      electronApp.windows().length > 0
+        ? electronApp.windows()[0]
+        : await electronApp.firstWindow()
+
+    // Auto-dismiss any JavaScript dialogs (e.g. beforeunload prompts).
+    // Sabaki's beforeunload handler sets returnValue which can trigger
+    // dialog events that block Playwright operations.
+    page.on('dialog', async (dialog) => {
+      await dialog.accept()
+    })
+
+    // Wait for the app to fully render
+    await page.waitForSelector('#goban', {timeout: 30000})
+
+    await use(page)
+  },
+})
+
+module.exports = {test}

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -1,0 +1,113 @@
+const path = require('path')
+
+/**
+ * Wait for the current game tree to have at least one child node,
+ * indicating an SGF file has been fully loaded and parsed.
+ */
+async function waitForGameLoad(page) {
+  await page.waitForFunction(
+    () => {
+      if (!window.__sabaki) return false
+      const tree =
+        window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+      return tree && tree.root.children.length > 0
+    },
+    {timeout: 10000},
+  )
+}
+
+/**
+ * Load an SGF file via the sabaki singleton and wait for it to parse.
+ */
+async function loadSgfAndWait(page, sgfPath) {
+  await page.evaluate((filePath) => {
+    window.__sabaki.loadFile(filePath)
+  }, sgfPath)
+
+  await waitForGameLoad(page)
+}
+
+/**
+ * Returns the depth (move number) of the current tree position.
+ */
+function getTreeDepth(page) {
+  return page.evaluate(() => {
+    const tree =
+      window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+    let pos = window.__sabaki.state.treePosition
+    let depth = 0
+    while (pos !== tree.root.id) {
+      pos = tree.get(pos).parentId
+      depth++
+    }
+    return depth
+  })
+}
+
+/**
+ * Attach engines, wait for them to be fully initialized (process spawned
+ * and list_commands response processed), and return their syncer IDs.
+ */
+async function attachAndWaitForEngines(page, engines) {
+  const syncerIds = await page.evaluate((engs) => {
+    const syncers = window.__sabaki.attachEngines(engs)
+    return syncers.map((s) => s.id)
+  }, engines)
+
+  // Wait until every syncer's process is running (_suspended === false)
+  // AND its list_commands response has been processed (commands array
+  // populated). This replaces the previous fixed 500ms delay.
+  await page.waitForFunction(
+    (ids) => {
+      const syncers = window.__sabaki.state.attachedEngineSyncers
+      return ids.every((id) => {
+        const s = syncers.find((x) => x.id === id)
+        return s && !s._suspended && s.commands && s.commands.length > 0
+      })
+    },
+    syncerIds,
+    {timeout: 15000},
+  )
+
+  return syncerIds
+}
+
+/**
+ * Detach the given engine syncers and wait for them to be removed from state.
+ */
+async function detachAndWait(page, syncerIds) {
+  await page.evaluate((ids) => {
+    window.__sabaki.detachEngines(ids)
+  }, syncerIds)
+
+  // Check that the specific IDs are gone, not just that the array is empty,
+  // so this stays correct even if other engines are attached concurrently.
+  await page.waitForFunction(
+    (ids) => {
+      const syncers = window.__sabaki.state.attachedEngineSyncers
+      return ids.every((id) => !syncers.some((s) => s.id === id))
+    },
+    syncerIds,
+    {timeout: 10000},
+  )
+}
+
+/**
+ * Absolute path to the resign engine test fixture.
+ */
+const enginePath = path.resolve(
+  __dirname,
+  '..',
+  'test',
+  'engines',
+  'resignEngine.js',
+)
+
+module.exports = {
+  waitForGameLoad,
+  loadSgfAndWait,
+  getTreeDepth,
+  attachAndWaitForEngines,
+  detachAndWait,
+  enginePath,
+}

--- a/e2e/renderer.spec.js
+++ b/e2e/renderer.spec.js
@@ -1,0 +1,181 @@
+const {expect} = require('@playwright/test')
+const path = require('path')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfAndWait, getTreeDepth, waitForGameLoad} = require('./helpers')
+
+test.describe('Renderer Integration Tests', () => {
+  test.describe('Navigation', () => {
+    test.beforeEach(async ({page}) => {
+      const sgfPath = path.resolve(
+        __dirname,
+        '..',
+        'test',
+        'sgf',
+        'pro_game.sgf',
+      )
+
+      await loadSgfAndWait(page, sgfPath)
+    })
+
+    test('goStep navigates forward and backward', async ({page}) => {
+      await page.evaluate(() => {
+        for (let i = 0; i < 5; i++) {
+          window.__sabaki.goStep(1)
+        }
+      })
+
+      expect(await getTreeDepth(page)).toBe(5)
+
+      await page.evaluate(() => {
+        for (let i = 0; i < 3; i++) {
+          window.__sabaki.goStep(-1)
+        }
+      })
+
+      expect(await getTreeDepth(page)).toBe(2)
+    })
+
+    test('goToEnd and goToBeginning jump correctly', async ({page}) => {
+      await page.evaluate(() => {
+        window.__sabaki.goToEnd()
+      })
+
+      const stonesAtEnd = await page.evaluate(() => {
+        return document.querySelectorAll('.shudan-sign_1, .shudan-sign_-1')
+          .length
+      })
+      expect(stonesAtEnd).toBeGreaterThan(0)
+
+      await page.evaluate(() => {
+        window.__sabaki.goToBeginning()
+      })
+
+      const isAtRoot = await page.evaluate(() => {
+        const tree =
+          window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+        return window.__sabaki.state.treePosition === tree.root.id
+      })
+      expect(isAtRoot).toBe(true)
+    })
+
+    test('arrow key navigation moves through game tree', async ({page}) => {
+      await page.evaluate(() => {
+        window.__sabaki.goToBeginning()
+      })
+
+      expect(await getTreeDepth(page)).toBe(0)
+
+      // ArrowDown triggers startAutoscrolling, which calls goStep(1)
+      // synchronously on the first tick. Poll for the state change
+      // rather than using a fixed timeout.
+      await page.keyboard.down('ArrowDown')
+
+      await page.waitForFunction(
+        () => {
+          const tree =
+            window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+          return window.__sabaki.state.treePosition !== tree.root.id
+        },
+        {timeout: 5000},
+      )
+
+      await page.keyboard.up('ArrowDown')
+
+      expect(await getTreeDepth(page)).toBeGreaterThan(0)
+    })
+  })
+
+  test.describe('Dialog Stubbing', () => {
+    test('file open dialog can be stubbed', async ({electronApp, page}) => {
+      const sgfPath = path.resolve(
+        __dirname,
+        '..',
+        'test',
+        'sgf',
+        'beginner_game.sgf',
+      )
+
+      // Stub the open dialog in the main process so showOpenDialog returns
+      // a specific file path instead of showing a native dialog.
+      await electronApp.evaluate(({dialog}, filePath) => {
+        dialog.showOpenDialog = async () => ({
+          canceled: false,
+          filePaths: [filePath],
+        })
+      }, sgfPath)
+
+      // loadFile() without args triggers the showOpenDialog stub
+      await page.evaluate(() => {
+        window.__sabaki.loadFile()
+      })
+
+      await waitForGameLoad(page)
+
+      const hasChildren = await page.evaluate(() => {
+        const tree =
+          window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+        return tree.root.children.length > 0
+      })
+      expect(hasChildren).toBe(true)
+    })
+  })
+
+  test.describe('Board Interaction', () => {
+    test('clicking vertex in edit mode places a stone', async ({page}) => {
+      await page.evaluate(() => {
+        window.__sabaki.setMode('edit')
+      })
+
+      await page.waitForFunction(
+        () => window.__sabaki && window.__sabaki.state.mode === 'edit',
+      )
+
+      const stonesBefore = await page.evaluate(() => {
+        return document.querySelectorAll('.shudan-sign_1, .shudan-sign_-1')
+          .length
+      })
+
+      const vertex = page.locator('.shudan-vertex').nth(50)
+      await vertex.click()
+
+      await page.waitForFunction(
+        (before) => {
+          const current = document.querySelectorAll(
+            '.shudan-sign_1, .shudan-sign_-1',
+          ).length
+          return current > before
+        },
+        stonesBefore,
+        {timeout: 5000},
+      )
+
+      const stonesAfter = await page.evaluate(() => {
+        return document.querySelectorAll('.shudan-sign_1, .shudan-sign_-1')
+          .length
+      })
+      expect(stonesAfter).toBeGreaterThan(stonesBefore)
+    })
+
+    test('new file creates empty board', async ({page}) => {
+      await page.evaluate(() => {
+        window.__sabaki.newFile()
+      })
+
+      await page.waitForFunction(
+        () => {
+          if (!window.__sabaki) return false
+          const tree =
+            window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+          return tree && tree.root.children.length === 0
+        },
+        {timeout: 5000},
+      )
+
+      const stonesOnBoard = await page.evaluate(() => {
+        return document.querySelectorAll('.shudan-sign_1, .shudan-sign_-1')
+          .length
+      })
+      expect(stonesOnBoard).toBe(0)
+    })
+  })
+})

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,0 +1,85 @@
+const {expect} = require('@playwright/test')
+const path = require('path')
+const {test} = require('./fixtures/electron-app')
+const {waitForGameLoad, loadSgfAndWait} = require('./helpers')
+
+test.describe('Smoke Tests', () => {
+  test('app launches and creates a window', async ({electronApp}) => {
+    const windows = electronApp.windows()
+    expect(windows.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('window title contains "Sabaki"', async ({page}) => {
+    const title = await page.title()
+    expect(title).toContain('Sabaki')
+  })
+
+  test('no black screen — goban renders', async ({page}) => {
+    const goban = page.locator('#goban')
+    await expect(goban).toBeVisible()
+
+    // Verify board intersections render (19x19 = 361 vertices minimum for default board)
+    const vertices = page.locator('.shudan-vertex')
+    const count = await vertices.count()
+    expect(count).toBeGreaterThanOrEqual(81) // At least 9x9
+  })
+
+  test('main layout elements present', async ({page}) => {
+    await expect(page.locator('#main')).toBeVisible()
+    await expect(page.locator('#bar')).toBeVisible()
+    await expect(page.locator('#mainlayout')).toBeVisible()
+  })
+
+  test('load SGF via IPC from main process', async ({electronApp, page}) => {
+    const sgfPath = path.resolve(__dirname, '..', 'test', 'sgf', 'pro_game.sgf')
+
+    // Load file through the main→renderer IPC channel (webContents.send),
+    // which mirrors how Electron sends load-file events (e.g. open-file, CLI arg).
+    await electronApp.evaluate(({BrowserWindow}, filePath) => {
+      const win = BrowserWindow.getAllWindows()[0]
+      win.webContents.send('load-file', filePath)
+    }, sgfPath)
+
+    await waitForGameLoad(page)
+
+    // Navigate to end so stones are visible
+    await page.evaluate(() => {
+      window.__sabaki.goToEnd()
+    })
+
+    // Verify some stones appeared on the board
+    const stones = page.locator('.shudan-sign_1, .shudan-sign_-1')
+    const stoneCount = await stones.count()
+    expect(stoneCount).toBeGreaterThan(0)
+  })
+
+  test('load SGF via sabaki singleton', async ({page}) => {
+    const sgfPath = path.resolve(
+      __dirname,
+      '..',
+      'test',
+      'sgf',
+      'beginner_game.sgf',
+    )
+
+    await loadSgfAndWait(page, sgfPath)
+
+    const hasChildren = await page.evaluate(() => {
+      const tree =
+        window.__sabaki.state.gameTrees[window.__sabaki.state.gameIndex]
+      return tree.root.children.length > 0
+    })
+    expect(hasChildren).toBe(true)
+  })
+
+  test('window resize', async ({electronApp, page}) => {
+    const browserWindow = await electronApp.browserWindow(page)
+    await browserWindow.evaluate((win) => win.setContentSize(800, 600))
+
+    // Poll until the resize takes effect rather than using a fixed timeout.
+    await expect(async () => {
+      const size = await browserWindow.evaluate((win) => win.getContentSize())
+      expect(size).toEqual([800, 600])
+    }).toPass({timeout: 5000})
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "winston": "^3.2.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.0",
         "concurrently": "^7.3.0",
         "electron": "^37.10.3",
         "electron-builder": "^26.4.0",
@@ -1467,6 +1468,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@primer/octicons": {
@@ -7721,6 +7738,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -112,14 +112,15 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.0",
     "concurrently": "^7.3.0",
     "electron": "^37.10.3",
     "electron-builder": "^26.4.0",
     "mocha": "^10.0.0",
-    "tsx": "^4.0.0",
     "onchange": "^7.1.0",
     "prettier": "3.8.1",
     "tmp": "^0.2.5",
+    "tsx": "^4.0.0",
     "webpack": "^5.104.1",
     "webpack-cli": "^6.0.1"
   },
@@ -141,6 +142,9 @@
     "dist:win32-portable": "npm run bundle && electron-builder -w portable --ia32 && node ./ci/mv.js ./dist/sabaki-vx.x.x-win.exe ./dist/sabaki-vx.x.x-win-ia32-portable.exe",
     "dist:win64-portable": "npm run bundle && electron-builder -w portable --x64 && node ./ci/mv.js ./dist/sabaki-vx.x.x-win.exe ./dist/sabaki-vx.x.x-win-x64-portable.exe",
     "dist:win": "npm run dist:win32 && npm run dist:win64 && npm run dist:win32-portable && npm run dist:win64-portable",
-    "i18n": "node ./ci/createI18n.js"
+    "i18n": "node ./ci/createI18n.js",
+    "test:e2e": "webpack --mode development && (command -v xvfb-run >/dev/null 2>&1 && xvfb-run npx playwright test || npx playwright test)",
+    "test:e2e:smoke": "webpack --mode development && (command -v xvfb-run >/dev/null 2>&1 && xvfb-run npx playwright test --project=smoke || npx playwright test --project=smoke)",
+    "test:e2e:headed": "webpack --mode development && npx playwright test"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,18 @@
+const {defineConfig} = require('@playwright/test')
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  timeout: 60000,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1, // Electron tests must run serially
+  reporter: process.env.CI ? 'github' : 'list',
+  projects: [
+    {name: 'smoke', testMatch: /smoke\.spec\.js/},
+    {
+      name: 'renderer',
+      testMatch: /renderer\.spec\.js/,
+      dependencies: ['smoke'],
+    },
+    {name: 'engine', testMatch: /engine\.spec\.js/, dependencies: ['smoke']},
+  ],
+})

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,6 +22,8 @@ import * as gametree from '../modules/gametree.js'
 import * as gtplogger from '../modules/gtplogger.js'
 import * as helper from '../modules/helper.js'
 
+if (process.env.SABAKI_E2E) window.__sabaki = sabaki
+
 const setting = {
   get: (key) => window.sabaki.setting.get(key),
   set: (key, value) => {


### PR DESCRIPTION
## Summary

- Add Playwright-based E2E tests for Electron app (`e2e/` directory)
- Three test tiers: smoke (app launch), renderer (UI interactions), engine (GTP integration)
- Shared fixtures and helpers for isolated test runs with stubbed dialogs
- CI workflow with `e2e` job that depends on `build`, uses node_modules caching and webpack bundle artifacts
- Update documentation (CONTRIBUTING.md, docs/guides/building-tests.md)

## Test plan

- [x] CI `build` job passes (unit tests, formatting)
- [x] CI `e2e` job passes (Playwright tests under xvfb-run)
- [x] Local `npm run test:e2e` works on macOS (window flashes, tests pass)
- [x] Local `npm run test:e2e:smoke` runs only smoke suite