### PR TITLE
Added keyboard shortcuts for variation-related menu items; also for toggling good/bad move

### DIFF
--- a/e2e/annotation-toggle.spec.js
+++ b/e2e/annotation-toggle.spec.js
@@ -1,0 +1,62 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// Coverage for sabaki.toggleMoveAnnotation — the helper behind the
+// "Toggle Good Move" / "Toggle Bad Move" menu items (menu.js). Move annotations
+// (TE/IT/DO/BM) are mutually exclusive, so toggling one on must clear any other,
+// and toggling the same one again clears it entirely. The exclusivity itself
+// lives in setComment; this exercises the toggle-on/off + replace behavior end
+// to end.
+
+// Root plus a single Black move, so the current position is a real move node.
+const SGF = '(;GM[1]FF[4]SZ[19];B[pd])'
+
+function moveProp(page, prop) {
+  return page.evaluate((p) => {
+    const s = window.__sabaki
+    const tree = s.state.gameTrees[s.state.gameIndex]
+    const data = tree.get(s.state.treePosition).data
+    return data[p] != null ? data[p] : null
+  }, prop)
+}
+
+async function toggle(page, annotation) {
+  await page.evaluate((a) => {
+    const s = window.__sabaki
+    s.toggleMoveAnnotation(s.state.treePosition, a)
+  }, annotation)
+  await waitForRender(page)
+}
+
+test.describe('toggleMoveAnnotation', () => {
+  test.beforeEach(async ({page}) => {
+    await loadSgfStringAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+    await waitForRender(page)
+  })
+
+  test('toggles a move annotation on, then off', async ({page}) => {
+    expect(await moveProp(page, 'TE')).toBeNull()
+
+    await toggle(page, 'TE')
+    expect(await moveProp(page, 'TE')).not.toBeNull()
+
+    await toggle(page, 'TE')
+    expect(await moveProp(page, 'TE')).toBeNull()
+  })
+
+  test('replaces an existing annotation instead of stacking them', async ({
+    page,
+  }) => {
+    await toggle(page, 'TE')
+    expect(await moveProp(page, 'TE')).not.toBeNull()
+    expect(await moveProp(page, 'BM')).toBeNull()
+
+    // Toggling Bad Move while Good Move is set must clear TE, not coexist —
+    // a node can never be annotated as both good and bad.
+    await toggle(page, 'BM')
+    expect(await moveProp(page, 'BM')).not.toBeNull()
+    expect(await moveProp(page, 'TE')).toBeNull()
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -49,5 +49,10 @@ module.exports = defineConfig({
       testMatch: /scoring-overrides\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'annotation-toggle',
+      testMatch: /annotation-toggle\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -683,7 +683,7 @@ class EngineItem extends Component {
         h('input', {
           type: 'text',
           placeholder: t(
-            'Path (e.g., /path/to/engine or C:\\path\\to\\engine.exe)'
+            'Path (e.g., /path/to/engine or C:\\path\\to\\engine.exe)',
           ),
           value: path || '',
           name: 'path',
@@ -696,7 +696,7 @@ class EngineItem extends Component {
         h('input', {
           type: 'text',
           placeholder: t(
-            'Optional arguments (e.g., -param1 value1 -param2 value2)'
+            'Optional arguments (e.g., -param1 value1 -param2 value2)',
           ),
           value: args || '',
           name: 'args',

--- a/src/menu.js
+++ b/src/menu.js
@@ -130,6 +130,7 @@ exports.get = function (props = {}) {
       submenu: [
         {
           label: i18n.t('menu.play', '&Toggle Player'),
+          accelerator: 'CmdOrCtrl+Shift+1',
           click: () =>
             sabaki.setPlayer(
               sabaki.state.treePosition,
@@ -258,27 +259,33 @@ exports.get = function (props = {}) {
         {type: 'separator'},
         {
           label: i18n.t('menu.edit', '&Copy Variation'),
+          accelerator: 'CmdOrCtrl+Alt+Shift+C',
           click: () => sabaki.copyVariation(sabaki.state.treePosition),
         },
         {
           label: i18n.t('menu.edit', 'Cu&t Variation'),
+          accelerator: 'CmdOrCtrl+Alt+Shift+X',
           click: () => sabaki.cutVariation(sabaki.state.treePosition),
         },
         {
           label: i18n.t('menu.edit', '&Paste Variation'),
+          accelerator: 'CmdOrCtrl+Alt+Shift+V',
           click: () => sabaki.pasteVariation(sabaki.state.treePosition),
         },
         {type: 'separator'},
         {
           label: i18n.t('menu.edit', 'Make Main &Variation'),
+          accelerator: 'CmdOrCtrl+Alt+Shift+Left',
           click: () => sabaki.makeMainVariation(sabaki.state.treePosition),
         },
         {
           label: i18n.t('menu.edit', 'Shift &Left'),
+          accelerator: 'CmdOrCtrl+Shift+Left',
           click: () => sabaki.shiftVariation(sabaki.state.treePosition, -1),
         },
         {
           label: i18n.t('menu.edit', 'Shift Ri&ght'),
+          accelerator: 'CmdOrCtrl+Shift+Right',
           click: () => sabaki.shiftVariation(sabaki.state.treePosition, 1),
         },
         {type: 'separator'},
@@ -296,8 +303,32 @@ exports.get = function (props = {}) {
         },
         {
           label: i18n.t('menu.edit', 'Remove &Other Variations'),
+          accelerator: 'CmdOrCtrl+Shift+Backspace',
           click: () => sabaki.removeOtherVariations(sabaki.state.treePosition),
         },
+        {type: 'separator'},
+        {
+          label: i18n.t('menu.edit', 'Toggle Good Move'),
+          accelerator: 'CmdOrCtrl+Shift+]',
+          click: () =>
+            // Adapted from the 'Toggle Hotspot' handler
+            sabaki.setComment(sabaki.state.treePosition, {
+              moveAnnotation:
+                sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
+                  .data.TE == null ? 'TE' : null
+            })
+        },
+        {
+          label: i18n.t('menu.edit', 'Toggle Bad Move'),
+          accelerator: 'CmdOrCtrl+Shift+[',
+          click: () =>
+            // Adapted from the 'Toggle Hotspot' handler
+            sabaki.setComment(sabaki.state.treePosition, {
+              moveAnnotation:
+                sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
+                  .data.BM == null ? 'BM' : null
+            })
+        }
       ],
     },
     {

--- a/src/menu.js
+++ b/src/menu.js
@@ -130,7 +130,7 @@ exports.get = function (props = {}) {
       submenu: [
         {
           label: i18n.t('menu.play', '&Toggle Player'),
-          accelerator: 'CmdOrCtrl+Shift+1',
+          accelerator: 'CmdOrCtrl+Shift+P',
           click: () =>
             sabaki.setPlayer(
               sabaki.state.treePosition,
@@ -315,8 +315,10 @@ exports.get = function (props = {}) {
             sabaki.setComment(sabaki.state.treePosition, {
               moveAnnotation:
                 sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
-                  .data.TE == null ? 'TE' : null
-            })
+                  .data.TE == null
+                  ? 'TE'
+                  : null,
+            }),
         },
         {
           label: i18n.t('menu.edit', 'Toggle Bad Move'),
@@ -326,9 +328,11 @@ exports.get = function (props = {}) {
             sabaki.setComment(sabaki.state.treePosition, {
               moveAnnotation:
                 sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
-                  .data.BM == null ? 'BM' : null
-            })
-        }
+                  .data.BM == null
+                  ? 'BM'
+                  : null,
+            }),
+        },
       ],
     },
     {

--- a/src/menu.js
+++ b/src/menu.js
@@ -311,27 +311,13 @@ exports.get = function (props = {}) {
           label: i18n.t('menu.edit', 'Toggle Good Move'),
           accelerator: 'CmdOrCtrl+Shift+]',
           click: () =>
-            // Adapted from the 'Toggle Hotspot' handler
-            sabaki.setComment(sabaki.state.treePosition, {
-              moveAnnotation:
-                sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
-                  .data.TE == null
-                  ? 'TE'
-                  : null,
-            }),
+            sabaki.toggleMoveAnnotation(sabaki.state.treePosition, 'TE'),
         },
         {
           label: i18n.t('menu.edit', 'Toggle Bad Move'),
           accelerator: 'CmdOrCtrl+Shift+[',
           click: () =>
-            // Adapted from the 'Toggle Hotspot' handler
-            sabaki.setComment(sabaki.state.treePosition, {
-              moveAnnotation:
-                sabaki.inferredState.gameTree.get(sabaki.state.treePosition)
-                  .data.BM == null
-                  ? 'BM'
-                  : null,
-            }),
+            sabaki.toggleMoveAnnotation(sabaki.state.treePosition, 'BM'),
         },
       ],
     },

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -2516,6 +2516,16 @@ class Sabaki extends EventEmitter {
     this.setCurrentTreePosition(newTree, treePosition)
   }
 
+  toggleMoveAnnotation(treePosition, annotation) {
+    // Move annotations (TE/IT/DO/BM) are mutually exclusive — setComment clears
+    // the others when one is set — so toggling one that's already present just
+    // clears it back to no annotation.
+    let node = this.inferredState.gameTree.get(treePosition)
+    this.setComment(treePosition, {
+      moveAnnotation: node.data[annotation] != null ? null : annotation,
+    })
+  }
+
   copyVariation(treePosition) {
     let node = this.inferredState.gameTree.get(treePosition)
     let copy = {


### PR DESCRIPTION
Added keyboard shortcuts for various existing menu items related to editing variations:

- CmdOrCtrl+Alt+Shift+C = Edit > Copy Variation
- CmdOrCtrl+Alt+Shift+X = Edit > Cut Variation
- CmdOrCtrl+Alt+Shift+V = Edit > Paste Variation
- CmdOrCtrl+Alt+Shift+Left = Edit > Make Main Variation
- CmdOrCtrl+Shift+Left = Edit > Shift Left
- CmdOrCtrl+Shift+Right = Edit > Shift Right
- CmdOrCtrl+Shift+Backspace = Edit > Remove Other Variations

Also added menu items for "Toggle Good Move" and "Toggle Bad Move" so we can use keyboard shortcuts for them.

- CmdOrCtrl+Shift+] = Edit > Toggle Good Move
- CmdOrCtrl+Shift+[ = Edit > Toggle Bad Move
