### PR TITLE
add keyboard shortcut for "Show Analysis Graph"

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -724,6 +724,7 @@ exports.get = function (props = {}) {
           type: 'checkbox',
           checked: !!showWinrateGraph,
           enabled: !!showGameGraph || !!showCommentBox,
+          accelerator: 'CmdOrCtrl+Shift+G',
           click: () => {
             toggleSetting('view.show_winrategraph')
             sabaki.setState(({showWinrateGraph}) => ({


### PR DESCRIPTION
Fixes #1020 

G is for "Graph"

Ctrl+G is already taken by "Go to Move Number" so need to add Shift