### PR TITLE
Add option to show score/winrate change instead of absolute value

### DIFF
--- a/e2e/analysis-value-display.spec.js
+++ b/e2e/analysis-value-display.spec.js
@@ -1,0 +1,134 @@
+const {expect} = require('@playwright/test')
+const path = require('path')
+const {test} = require('./fixtures/electron-app')
+const {
+  loadSgfAndWait,
+  attachAndWaitForEngines,
+  detachAndWait,
+  waitForRender,
+} = require('./helpers')
+
+// End-to-end coverage of the "Analysis Value Display" setting
+// (board.analysis_value_type, menu.js / Goban.js): 'absolute' shows each
+// candidate move's raw winrate, while 'change' shows its difference from the
+// best move, so the best move always reads as 0 and every other move reads
+// as its cost relative to it.
+//
+// Uses the same replay engine + golden transcript as engine-analysis.spec.js,
+// so this exercises the real attach -> analyze -> heatmap render path without
+// needing a live engine.
+
+const RES = path.resolve(
+  __dirname,
+  '..',
+  'test',
+  'resources',
+  'engine-transcripts',
+)
+const REPLAY_ENGINE = path.resolve(
+  __dirname,
+  '..',
+  'test',
+  'engines',
+  'replayEngine.js',
+)
+const SGF = path.join(RES, 'sgf', 'endgame-9.sgf')
+const TRANSCRIPT = path.join(RES, 'katago-1.16.4', 'endgame-9.kata-analyze.txt')
+
+async function setValueType(page, type) {
+  await page.evaluate(async (t) => {
+    await window.sabaki.setting.set('board.analysis_value_type', t)
+  }, type)
+  await page.waitForFunction(
+    (t) => window.__sabaki.state.analysisValueType === t,
+    type,
+  )
+  await waitForRender(page)
+}
+
+function heatLabelText(page, [x, y]) {
+  return page.evaluate(
+    ([vx, vy]) => {
+      const el = document.querySelector(
+        `.shudan-vertex[data-x="${vx}"][data-y="${vy}"] .shudan-heatlabel`,
+      )
+      return el ? el.textContent : null
+    },
+    [x, y],
+  )
+}
+
+test.describe('Analysis Value Display', () => {
+  test('"change" mode shows the best move as 0 and other moves as a delta from it', async ({
+    page,
+  }) => {
+    await loadSgfAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+
+    const [syncerId] = await attachAndWaitForEngines(page, [
+      {
+        name: 'ReplayEngine',
+        path: process.execPath,
+        args: `"${REPLAY_ENGINE}" --transcript "${TRANSCRIPT}" --analyze-command kata-analyze`,
+      },
+    ])
+
+    try {
+      await page.evaluate((id) => window.__sabaki.startAnalysis(id), syncerId)
+
+      // Wait for the engine's analysis to settle (mirrors engine-analysis.spec.js):
+      // SBKV/SBKS land on the node only once a full analysis update has been
+      // processed, so by that point state.analysis.variations is populated too.
+      await page.waitForFunction(
+        () => {
+          const s = window.__sabaki
+          const tree = s.state.gameTrees[s.state.gameIndex]
+          const node = tree.get(s.state.treePosition)
+          return node != null && node.data != null && node.data.SBKV != null
+        },
+        {timeout: 15000},
+      )
+
+      await waitForRender(page)
+
+      // Identify the best move (the one analysis.winrate is taken from) and a
+      // clearly inferior, displayed (visits >= 10) move, so the assertions
+      // don't depend on the exact transcript values.
+      const {best, inferior} = await page.evaluate(() => {
+        const {variations, winrate} = window.__sabaki.state.analysis
+        const bestVariation = variations.find((v) => v.winrate === winrate)
+        const inferiorVariation = variations
+          .filter((v) => v.visits >= 10 && v.winrate < winrate)
+          .sort((a, b) => a.winrate - b.winrate)[0]
+        return {
+          best: bestVariation && bestVariation.vertex,
+          inferior: inferiorVariation && inferiorVariation.vertex,
+        }
+      })
+
+      expect(best).toBeTruthy()
+      expect(inferior).toBeTruthy()
+
+      await setValueType(page, 'absolute')
+      const bestAbsolute = await heatLabelText(page, best)
+      const inferiorAbsolute = await heatLabelText(page, inferior)
+
+      // Absolute winrates are decisive percentages here; neither reads as 0,
+      // and a winrate can never be negative.
+      expect(bestAbsolute).not.toMatch(/^0%/)
+      expect(inferiorAbsolute).not.toMatch(/^-/)
+
+      await setValueType(page, 'change')
+      const bestChange = await heatLabelText(page, best)
+      const inferiorChange = await heatLabelText(page, inferior)
+
+      // The best move's delta from itself is always 0; the inferior move's
+      // delta is its cost relative to the best move, so it's negative.
+      expect(bestChange).toMatch(/^0%/)
+      expect(inferiorChange).toMatch(/^-/)
+    } finally {
+      await page.evaluate(() => window.__sabaki.stopAnalysis())
+      await detachAndWait(page, [syncerId])
+    }
+  })
+})

--- a/e2e/analysis-value-display.spec.js
+++ b/e2e/analysis-value-display.spec.js
@@ -59,6 +59,15 @@ function heatLabelText(page, [x, y]) {
 }
 
 test.describe('Analysis Value Display', () => {
+  test('defaults to "absolute" on a fresh startup, before any setting.set call', async ({
+    page,
+  }) => {
+    const analysisValueType = await page.evaluate(
+      () => window.__sabaki.state.analysisValueType,
+    )
+    expect(analysisValueType).toBe('absolute')
+  })
+
   test('"change" mode shows the best move as 0 and other moves as a delta from it', async ({
     page,
   }) => {

--- a/e2e/analysis-value-display.spec.js
+++ b/e2e/analysis-value-display.spec.js
@@ -10,7 +10,7 @@ const {
 
 // End-to-end coverage of the "Analysis Value Display" setting
 // (board.analysis_value_type, menu.js / Goban.js): 'absolute' shows each
-// candidate move's raw winrate, while 'change' shows its difference from the
+// candidate move's raw winrate, while 'relative' shows its difference from the
 // best move, so the best move always reads as 0 and every other move reads
 // as its cost relative to it.
 //
@@ -68,7 +68,7 @@ test.describe('Analysis Value Display', () => {
     expect(analysisValueType).toBe('absolute')
   })
 
-  test('"change" mode shows the best move as 0 and other moves as a delta from it', async ({
+  test('"relative" mode shows the best move as 0 and other moves as a delta from it', async ({
     page,
   }) => {
     await loadSgfAndWait(page, SGF)
@@ -127,14 +127,14 @@ test.describe('Analysis Value Display', () => {
       expect(bestAbsolute).not.toMatch(/^0%/)
       expect(inferiorAbsolute).not.toMatch(/^-/)
 
-      await setValueType(page, 'change')
-      const bestChange = await heatLabelText(page, best)
-      const inferiorChange = await heatLabelText(page, inferior)
+      await setValueType(page, 'relative')
+      const bestRelative = await heatLabelText(page, best)
+      const inferiorRelative = await heatLabelText(page, inferior)
 
       // The best move's delta from itself is always 0; the inferior move's
       // delta is its cost relative to the best move, so it's negative.
-      expect(bestChange).toMatch(/^0%/)
-      expect(inferiorChange).toMatch(/^-/)
+      expect(bestRelative).toMatch(/^0%/)
+      expect(inferiorRelative).toMatch(/^-/)
     } finally {
       await page.evaluate(() => window.__sabaki.stopAnalysis())
       await detachAndWait(page, [syncerId])

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -54,5 +54,10 @@ module.exports = defineConfig({
       testMatch: /annotation-toggle\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'analysis-value-display',
+      testMatch: /analysis-value-display\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -359,7 +359,7 @@ class App extends Component {
         showMenuBar: state.showMenuBar,
         disableAll: state.busy > 0,
         analysisType: state.analysisType,
-        scoreLeadType: state.scoreLeadType,
+        analysisValueType: state.analysisValueType,
         showAnalysis: state.showAnalysis,
         showCoordinates: state.showCoordinates,
         coordinatesType: state.coordinatesType,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -359,6 +359,7 @@ class App extends Component {
         showMenuBar: state.showMenuBar,
         disableAll: state.busy > 0,
         analysisType: state.analysisType,
+        scoreLeadType: state.scoreLeadType,
         showAnalysis: state.showAnalysis,
         showCoordinates: state.showCoordinates,
         coordinatesType: state.coordinatesType,

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -219,7 +219,7 @@ export default class Goban extends Component {
       paintMap = [],
       analysis,
       analysisType,
-      scoreLeadType,
+      analysisValueType,
       highlightVertices = [],
       dimmedStones = [],
 
@@ -453,9 +453,13 @@ export default class Goban extends Component {
       } of analysis.variations) {
         let strength = Math.round((visits * winrate * 8) / maxVisitsWin) + 1
 
+        if (winrate !== null && analysisValueType === 'change') {
+          winrate -= analysis.winrate
+        }
         winrate =
           strength <= 3 ? Math.floor(winrate) : Math.floor(winrate * 10) / 10
-        if (scoreLead !== null && scoreLeadType === 'change') {
+        if (winrate === 0) winrate = 0 // Avoid -0
+        if (scoreLead !== null && analysisValueType === 'change') {
           scoreLead -= analysis.scoreLead
         }
         scoreLead = scoreLead == null ? null : Math.round(scoreLead * 10) / 10

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -4,6 +4,7 @@ import sgf from '@sabaki/sgf'
 import {BoundedGoban} from '@sabaki/shudan'
 
 import i18n from '../i18n.js'
+import {getAnalysisHeatMapCell} from '../modules/analysis.js'
 import * as gametree from '../modules/gametree.js'
 import * as gobantransformer from '../modules/gobantransformer.js'
 import * as helper from '../modules/helper.js'
@@ -445,44 +446,16 @@ export default class Goban extends Component {
       )
       heatMap = board.signMap.map((row) => row.map((_) => null))
 
-      for (let {
-        vertex: [x, y],
-        visits,
-        winrate,
-        scoreLead,
-      } of analysis.variations) {
-        let strength = Math.round((visits * winrate * 8) / maxVisitsWin) + 1
+      for (let variation of analysis.variations) {
+        let [x, y] = variation.vertex
 
-        if (winrate !== null && analysisValueType === 'change') {
-          winrate -= analysis.winrate
-        }
-        winrate =
-          strength <= 3 ? Math.floor(winrate) : Math.floor(winrate * 10) / 10
-        if (winrate === 0) winrate = 0 // Avoid -0
-        if (scoreLead !== null && analysisValueType === 'change') {
-          scoreLead -= analysis.scoreLead
-        }
-        scoreLead = scoreLead == null ? null : Math.round(scoreLead * 10) / 10
-        if (scoreLead === 0) scoreLead = 0 // Avoid -0
-
-        heatMap[y][x] = {
-          strength,
-          text:
-            visits < 10
-              ? ''
-              : [
-                  analysisType === 'winrate'
-                    ? i18n.formatNumber(winrate) +
-                      (Math.floor(winrate) === winrate ? '%' : '')
-                    : analysisType === 'scoreLead' && scoreLead != null
-                      ? (scoreLead >= 0 ? '+' : '') +
-                        i18n.formatNumber(scoreLead)
-                      : '–',
-                  visits < 1000
-                    ? i18n.formatNumber(visits)
-                    : i18n.formatNumber(Math.round(visits / 100) / 10) + 'k',
-                ].join('\n'),
-        }
+        heatMap[y][x] = getAnalysisHeatMapCell(
+          variation,
+          analysis,
+          maxVisitsWin,
+          {analysisType, analysisValueType},
+          i18n.formatNumber,
+        )
       }
     }
 

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -219,6 +219,7 @@ export default class Goban extends Component {
       paintMap = [],
       analysis,
       analysisType,
+      scoreLeadType,
       highlightVertices = [],
       dimmedStones = [],
 
@@ -454,6 +455,9 @@ export default class Goban extends Component {
 
         winrate =
           strength <= 3 ? Math.floor(winrate) : Math.floor(winrate * 10) / 10
+        if (scoreLead !== null && scoreLeadType === 'change') {
+          scoreLead -= analysis.scoreLead
+        }
         scoreLead = scoreLead == null ? null : Math.round(scoreLead * 10) / 10
         if (scoreLead === 0) scoreLead = 0 // Avoid -0
 

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -91,7 +91,7 @@ export default class MainView extends Component {
 
       highlightVertices,
       analysisType,
-      scoreLeadType,
+      analysisValueType,
       showAnalysis,
       showCoordinates,
       showMoveColorization,
@@ -140,7 +140,7 @@ export default class MainView extends Component {
           highlightVertices:
             findVertex && mode === 'find' ? [findVertex] : highlightVertices,
           analysisType,
-          scoreLeadType,
+          analysisValueType,
           analysis:
             showAnalysis &&
             analysisTreePosition != null &&

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -91,6 +91,7 @@ export default class MainView extends Component {
 
       highlightVertices,
       analysisType,
+      scoreLeadType,
       showAnalysis,
       showCoordinates,
       showMoveColorization,
@@ -139,6 +140,7 @@ export default class MainView extends Component {
           highlightVertices:
             findVertex && mode === 'find' ? [findVertex] : highlightVertices,
           analysisType,
+          scoreLeadType,
           analysis:
             showAnalysis &&
             analysisTreePosition != null &&

--- a/src/menu.js
+++ b/src/menu.js
@@ -642,6 +642,7 @@ exports.get = function (props = {}) {
               label: i18n.t('menu.view', '&Absolute'),
               type: 'checkbox',
               checked: analysisValueType === 'absolute',
+              accelerator: 'CmdOrCtrl+Shift+V',
               click: () => {
                 setting.set(
                   'board.analysis_value_type',
@@ -655,6 +656,7 @@ exports.get = function (props = {}) {
               label: i18n.t('menu.view', '&Change'),
               type: 'checkbox',
               checked: analysisValueType === 'change',
+              accelerator: 'CmdOrCtrl+Shift+V',
               click: () => {
                 setting.set(
                   'board.analysis_value_type',

--- a/src/menu.js
+++ b/src/menu.js
@@ -30,6 +30,7 @@ exports.get = function (props = {}) {
     disableAll,
     disableGameLoading,
     analysisType,
+    scoreLeadType,
     showAnalysis,
     showCoordinates,
     coordinatesType,
@@ -634,6 +635,38 @@ exports.get = function (props = {}) {
             },
           ],
         },
+        {
+          label: i18n.t('menu.view', 'Score Lead Display'),
+          submenu: [
+            {
+              label: i18n.t('menu.view', '&Absolute'),
+              type: 'checkbox',
+              checked: scoreLeadType === 'absolute',
+              click: () => {
+                setting.set(
+                  'board.scorelead_type',
+                  setting.get('board.scorelead_type') === 'absolute'
+                    ? 'change'
+                    : 'absolute'
+                )
+              }
+            },
+            {
+              label: i18n.t('menu.view', '&Change'),
+              type: 'checkbox',
+              checked: scoreLeadType === 'change',
+              click: () => {
+                setting.set(
+                  'board.scorelead_type',
+                  setting.get('board.scorelead_type') === 'change'
+                    ? 'absolute'
+                    : 'change'
+                )
+              }
+            }
+          ]
+        },
+
         {type: 'separator'},
         {
           label: i18n.t('menu.view', 'Show &Coordinates'),

--- a/src/menu.js
+++ b/src/menu.js
@@ -30,7 +30,7 @@ exports.get = function (props = {}) {
     disableAll,
     disableGameLoading,
     analysisType,
-    scoreLeadType,
+    analysisValueType,
     showAnalysis,
     showCoordinates,
     coordinatesType,
@@ -636,35 +636,35 @@ exports.get = function (props = {}) {
           ],
         },
         {
-          label: i18n.t('menu.view', 'Score Lead Display'),
+          label: i18n.t('menu.view', 'Analysis Value Display'),
           submenu: [
             {
               label: i18n.t('menu.view', '&Absolute'),
               type: 'checkbox',
-              checked: scoreLeadType === 'absolute',
+              checked: analysisValueType === 'absolute',
               click: () => {
                 setting.set(
-                  'board.scorelead_type',
-                  setting.get('board.scorelead_type') === 'absolute'
+                  'board.analysis_value_type',
+                  setting.get('board.analysis_value_type') === 'absolute'
                     ? 'change'
-                    : 'absolute'
+                    : 'absolute',
                 )
-              }
+              },
             },
             {
               label: i18n.t('menu.view', '&Change'),
               type: 'checkbox',
-              checked: scoreLeadType === 'change',
+              checked: analysisValueType === 'change',
               click: () => {
                 setting.set(
-                  'board.scorelead_type',
-                  setting.get('board.scorelead_type') === 'change'
+                  'board.analysis_value_type',
+                  setting.get('board.analysis_value_type') === 'change'
                     ? 'absolute'
-                    : 'change'
+                    : 'change',
                 )
-              }
-            }
-          ]
+              },
+            },
+          ],
         },
 
         {type: 'separator'},

--- a/src/menu.js
+++ b/src/menu.js
@@ -633,11 +633,7 @@ exports.get = function (props = {}) {
                 )
               },
             },
-          ],
-        },
-        {
-          label: i18n.t('menu.view', 'Analysis Value Display'),
-          submenu: [
+            {type: 'separator'},
             {
               label: i18n.t('menu.view', '&Absolute'),
               type: 'checkbox',
@@ -647,22 +643,22 @@ exports.get = function (props = {}) {
                 setting.set(
                   'board.analysis_value_type',
                   setting.get('board.analysis_value_type') === 'absolute'
-                    ? 'change'
+                    ? 'relative'
                     : 'absolute',
                 )
               },
             },
             {
-              label: i18n.t('menu.view', '&Change'),
+              label: i18n.t('menu.view', '&Relative'),
               type: 'checkbox',
-              checked: analysisValueType === 'change',
+              checked: analysisValueType === 'relative',
               accelerator: 'CmdOrCtrl+Shift+V',
               click: () => {
                 setting.set(
                   'board.analysis_value_type',
-                  setting.get('board.analysis_value_type') === 'change'
+                  setting.get('board.analysis_value_type') === 'relative'
                     ? 'absolute'
-                    : 'change',
+                    : 'relative',
                 )
               },
             },

--- a/src/modules/analysis.js
+++ b/src/modules/analysis.js
@@ -79,7 +79,7 @@ function normalizeWinrate(winrate, format) {
 //
 // `analysis` is the position-level summary (the best move's winrate/scoreLead,
 // per enginesyncer.js), used as the reference point when `analysisValueType`
-// is 'change' — so the best move's cell reads as 0 and every other variation
+// is 'relative' — so the best move's cell reads as 0 and every other variation
 // reads as its cost relative to the best move, rather than an absolute value.
 export function getAnalysisHeatMapCell(
   {visits, winrate, scoreLead},
@@ -92,13 +92,13 @@ export function getAnalysisHeatMapCell(
   // absolute quality, regardless of how its label is displayed.
   let strength = Math.round((visits * winrate * 8) / maxVisitsWin) + 1
 
-  if (winrate !== null && analysisValueType === 'change') {
+  if (winrate !== null && analysisValueType === 'relative') {
     winrate -= analysis.winrate
   }
   winrate = strength <= 3 ? Math.floor(winrate) : Math.floor(winrate * 10) / 10
   if (winrate === 0) winrate = 0 // Avoid -0
 
-  if (scoreLead !== null && analysisValueType === 'change') {
+  if (scoreLead !== null && analysisValueType === 'relative') {
     scoreLead -= analysis.scoreLead
   }
   scoreLead = scoreLead == null ? null : Math.round(scoreLead * 10) / 10

--- a/src/modules/analysis.js
+++ b/src/modules/analysis.js
@@ -74,3 +74,51 @@ function normalizeWinrate(winrate, format) {
   let isFloat = format == null ? winrate.includes('.') : format === 'float'
   return isFloat ? +winrate * 100 : +winrate / 100
 }
+
+// Builds one heatmap cell (board overlay strength + label) for a variation.
+//
+// `analysis` is the position-level summary (the best move's winrate/scoreLead,
+// per enginesyncer.js), used as the reference point when `analysisValueType`
+// is 'change' — so the best move's cell reads as 0 and every other variation
+// reads as its cost relative to the best move, rather than an absolute value.
+export function getAnalysisHeatMapCell(
+  {visits, winrate, scoreLead},
+  analysis,
+  maxVisitsWin,
+  {analysisType, analysisValueType},
+  formatNumber,
+) {
+  // Strength (the overlay color intensity) always reflects the move's
+  // absolute quality, regardless of how its label is displayed.
+  let strength = Math.round((visits * winrate * 8) / maxVisitsWin) + 1
+
+  if (winrate !== null && analysisValueType === 'change') {
+    winrate -= analysis.winrate
+  }
+  winrate = strength <= 3 ? Math.floor(winrate) : Math.floor(winrate * 10) / 10
+  if (winrate === 0) winrate = 0 // Avoid -0
+
+  if (scoreLead !== null && analysisValueType === 'change') {
+    scoreLead -= analysis.scoreLead
+  }
+  scoreLead = scoreLead == null ? null : Math.round(scoreLead * 10) / 10
+  if (scoreLead === 0) scoreLead = 0 // Avoid -0
+
+  return {
+    strength,
+    text:
+      visits < 10
+        ? ''
+        : [
+            analysisType === 'winrate'
+              ? formatNumber(winrate) +
+                (Math.floor(winrate) === winrate ? '%' : '')
+              : analysisType === 'scoreLead' && scoreLead != null
+                ? (scoreLead >= 0 ? '+' : '') + formatNumber(scoreLead)
+                : '–',
+            visits < 1000
+              ? formatNumber(visits)
+              : formatNumber(Math.round(visits / 100) / 10) + 'k',
+          ].join('\n'),
+  }
+}

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -72,6 +72,7 @@ class Sabaki extends EventEmitter {
       highlightVertices: [],
       playVariation: null,
       analysisType: null,
+      scoreLeadType: null,
       coordinatesType: null,
       showAnalysis: null,
       showCoordinates: null,
@@ -311,6 +312,7 @@ class Sabaki extends EventEmitter {
     let data = {
       'app.zoom_factor': 'zoomFactor',
       'board.analysis_type': 'analysisType',
+      'board.scorelead_type': 'scoreLeadType',
       'board.show_analysis': 'showAnalysis',
       'view.show_menubar': 'showMenuBar',
       'view.show_coordinates': 'showCoordinates',

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -72,7 +72,7 @@ class Sabaki extends EventEmitter {
       highlightVertices: [],
       playVariation: null,
       analysisType: null,
-      scoreLeadType: null,
+      analysisValueType: null,
       coordinatesType: null,
       showAnalysis: null,
       showCoordinates: null,
@@ -312,7 +312,7 @@ class Sabaki extends EventEmitter {
     let data = {
       'app.zoom_factor': 'zoomFactor',
       'board.analysis_type': 'analysisType',
-      'board.scorelead_type': 'scoreLeadType',
+      'board.analysis_value_type': 'analysisValueType',
       'board.show_analysis': 'showAnalysis',
       'view.show_menubar': 'showMenuBar',
       'view.show_coordinates': 'showCoordinates',

--- a/src/setting.js
+++ b/src/setting.js
@@ -47,7 +47,7 @@ let defaults = {
   'autoscroll.min_interval': 50,
   'board.analysis_interval': 50,
   'board.analysis_type': 'winrate',
-  'board.scorelead_type': 'absolute',
+  'board.analysis_value_type': 'absolute',
   'board.show_analysis': true,
   'board.variation_replay_mode': 'move_by_move',
   'board.variation_replay_interval': 500,

--- a/src/setting.js
+++ b/src/setting.js
@@ -47,6 +47,7 @@ let defaults = {
   'autoscroll.min_interval': 50,
   'board.analysis_interval': 50,
   'board.analysis_type': 'winrate',
+  'board.scorelead_type': 'absolute',
   'board.show_analysis': true,
   'board.variation_replay_mode': 'move_by_move',
   'board.variation_replay_interval': 500,

--- a/test/analysisTests.js
+++ b/test/analysisTests.js
@@ -3,7 +3,7 @@ import {readFileSync, existsSync} from 'fs'
 import {join} from 'path'
 import {fromDimensions as newBoard} from '@sabaki/go-board'
 
-import {parseAnalysis} from '../src/modules/analysis.js'
+import {parseAnalysis, getAnalysisHeatMapCell} from '../src/modules/analysis.js'
 
 // These tests verify the GTP analysis parser (the SBKV / scoreLead extraction
 // path) against GOLDEN TRANSCRIPTS  (real `info ...` lines recorded from real
@@ -211,5 +211,151 @@ describe('parseAnalysis (parser logic)', () => {
       parseAnalysis('info move Q16 visits 10 pv Q16', board),
       [],
     )
+  })
+})
+
+// Focused unit cases for the heatmap cell builder used by the board overlay
+// (Goban.js). `formatNumber` is stubbed to plain `String` since locale
+// formatting isn't this function's concern.
+describe('getAnalysisHeatMapCell', () => {
+  const formatNumber = (n) => String(n)
+  // A large maxVisitsWin keeps `strength` in the <=3 branch (Math.floor, no
+  // decimal) unless a test deliberately shrinks it to exercise the >3 branch.
+  const maxVisitsWin = 100000
+
+  it('shows the absolute winrate with a % suffix on whole numbers', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 60, scoreLead: 2},
+      {winrate: 60, scoreLead: 2},
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '60%\n10')
+  })
+
+  it('shows the absolute scoreLead with a leading + when non-negative', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 60, scoreLead: 2.34},
+      {winrate: 60, scoreLead: 2.34},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '+2.3\n10')
+  })
+
+  it('shows a negative absolute scoreLead without a + prefix', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 40, scoreLead: -1.27},
+      {winrate: 60, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '-1.3\n10')
+  })
+
+  it('shows – when scoreLead is null (Leela-Zero dialect)', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 60, scoreLead: null},
+      {winrate: 60, scoreLead: null},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '–\n10')
+  })
+
+  it('shows an empty label when visits are below the display threshold', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 5, winrate: 60, scoreLead: 1},
+      {winrate: 60, scoreLead: 1},
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '')
+  })
+
+  it('shows 0 for the best move’s winrate in change mode', () => {
+    // The reference `analysis.winrate` is the max across variations (the
+    // best move), so the best move's own delta is always 0.
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 65, scoreLead: 5},
+      {winrate: 65, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'change'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '0%\n10')
+  })
+
+  it('shows a negative winrate delta for an inferior move in change mode', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 50, scoreLead: 2},
+      {winrate: 65, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'change'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '-15%\n10')
+  })
+
+  it('shows +0 for the best move’s scoreLead in change mode', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 65, scoreLead: 5},
+      {winrate: 65, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '+0\n10')
+  })
+
+  it('shows a negative scoreLead delta for an inferior move in change mode', () => {
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 50, scoreLead: 2},
+      {winrate: 65, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '-3\n10')
+  })
+
+  it('normalizes a -0 scoreLead delta to 0 instead of printing "-0"', () => {
+    // Math.round(-0.4) === -0 in JS, so a small negative delta that rounds to
+    // zero can surface as -0 without the explicit guard in the implementation.
+    let cell = getAnalysisHeatMapCell(
+      {visits: 10, winrate: 60, scoreLead: 4.996},
+      {winrate: 60, scoreLead: 5},
+      maxVisitsWin,
+      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      formatNumber,
+    )
+    assert.strictEqual(cell.text, '+0\n10')
+  })
+
+  it('computes strength from the absolute winrate regardless of analysisValueType', () => {
+    let variation = {visits: 50, winrate: 80, scoreLead: 3}
+    let analysis = {winrate: 90, scoreLead: 10}
+
+    let absoluteCell = getAnalysisHeatMapCell(
+      variation,
+      analysis,
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'absolute'},
+      formatNumber,
+    )
+    let changeCell = getAnalysisHeatMapCell(
+      variation,
+      analysis,
+      maxVisitsWin,
+      {analysisType: 'winrate', analysisValueType: 'change'},
+      formatNumber,
+    )
+
+    assert.strictEqual(absoluteCell.strength, changeCell.strength)
   })
 })

--- a/test/analysisTests.js
+++ b/test/analysisTests.js
@@ -278,47 +278,47 @@ describe('getAnalysisHeatMapCell', () => {
     assert.strictEqual(cell.text, '')
   })
 
-  it('shows 0 for the best move’s winrate in change mode', () => {
+  it('shows 0 for the best move’s winrate in relative mode', () => {
     // The reference `analysis.winrate` is the max across variations (the
     // best move), so the best move's own delta is always 0.
     let cell = getAnalysisHeatMapCell(
       {visits: 10, winrate: 65, scoreLead: 5},
       {winrate: 65, scoreLead: 5},
       maxVisitsWin,
-      {analysisType: 'winrate', analysisValueType: 'change'},
+      {analysisType: 'winrate', analysisValueType: 'relative'},
       formatNumber,
     )
     assert.strictEqual(cell.text, '0%\n10')
   })
 
-  it('shows a negative winrate delta for an inferior move in change mode', () => {
+  it('shows a negative winrate delta for an inferior move in relative mode', () => {
     let cell = getAnalysisHeatMapCell(
       {visits: 10, winrate: 50, scoreLead: 2},
       {winrate: 65, scoreLead: 5},
       maxVisitsWin,
-      {analysisType: 'winrate', analysisValueType: 'change'},
+      {analysisType: 'winrate', analysisValueType: 'relative'},
       formatNumber,
     )
     assert.strictEqual(cell.text, '-15%\n10')
   })
 
-  it('shows +0 for the best move’s scoreLead in change mode', () => {
+  it('shows +0 for the best move’s scoreLead in relative mode', () => {
     let cell = getAnalysisHeatMapCell(
       {visits: 10, winrate: 65, scoreLead: 5},
       {winrate: 65, scoreLead: 5},
       maxVisitsWin,
-      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      {analysisType: 'scoreLead', analysisValueType: 'relative'},
       formatNumber,
     )
     assert.strictEqual(cell.text, '+0\n10')
   })
 
-  it('shows a negative scoreLead delta for an inferior move in change mode', () => {
+  it('shows a negative scoreLead delta for an inferior move in relative mode', () => {
     let cell = getAnalysisHeatMapCell(
       {visits: 10, winrate: 50, scoreLead: 2},
       {winrate: 65, scoreLead: 5},
       maxVisitsWin,
-      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      {analysisType: 'scoreLead', analysisValueType: 'relative'},
       formatNumber,
     )
     assert.strictEqual(cell.text, '-3\n10')
@@ -331,7 +331,7 @@ describe('getAnalysisHeatMapCell', () => {
       {visits: 10, winrate: 60, scoreLead: 4.996},
       {winrate: 60, scoreLead: 5},
       maxVisitsWin,
-      {analysisType: 'scoreLead', analysisValueType: 'change'},
+      {analysisType: 'scoreLead', analysisValueType: 'relative'},
       formatNumber,
     )
     assert.strictEqual(cell.text, '+0\n10')
@@ -348,14 +348,14 @@ describe('getAnalysisHeatMapCell', () => {
       {analysisType: 'winrate', analysisValueType: 'absolute'},
       formatNumber,
     )
-    let changeCell = getAnalysisHeatMapCell(
+    let relativeCell = getAnalysisHeatMapCell(
       variation,
       analysis,
       maxVisitsWin,
-      {analysisType: 'winrate', analysisValueType: 'change'},
+      {analysisType: 'winrate', analysisValueType: 'relative'},
       formatNumber,
     )
 
-    assert.strictEqual(absoluteCell.strength, changeCell.strength)
+    assert.strictEqual(absoluteCell.strength, relativeCell.strength)
   })
 })


### PR DESCRIPTION
Fixes #843 

- Adds a new View menu "Analysis Value Display" with options "Absolute" and "Change" to pick whether to show the absolute winrate/scorelead or the change from the previous value.
- Adds a keyboard shortcut Ctrl+Shift+V to toggle between these two settings (V stands for "Value").
- Factors the logic for determining what value to display out of `Goban.js` into `getAnalysisHeatMapCell` in `analysis.js` to enable unit testing.

Disclaimer: I used Claude Code to write the tests.

<img width="1668" height="863" alt="image" src="https://github.com/user-attachments/assets/a212a418-60a0-400b-ba18-85a871984324" />
