### PR TITLE
Fix Ctrl-Q not quitting on Linux

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -202,6 +202,7 @@ function buildMenu(props = {}) {
           ({
             newWindow,
             checkForUpdates: () => checkForUpdates({showFailDialogs: true}),
+            quit: () => app.quit(),
           })[key]()
 
         delete item.clickMain

--- a/src/menu.js
+++ b/src/menu.js
@@ -120,7 +120,7 @@ exports.get = function (props = {}) {
         {
           label: i18n.t('menu.file', '&Quit'),
           accelerator: 'CmdOrCtrl+Q',
-          click: () => app.quit(),
+          clickMain: 'quit',
         },
       ],
     },


### PR DESCRIPTION
Fixes #1023 

Disclaimer: This PR and the following description were generated by Claude Code. I tested that the fix works on Linux, but I didn't test whether it changes behavior on other operating systems.

# Fix Ctrl+Q not quitting the app on Linux

## Summary

`Ctrl+Q` (the Quit accelerator) silently did nothing on Linux and Windows.

The Quit menu item used `click: () => app.quit()`. Menu items with a `click`
handler aren't run in the main process — `buildMenu()` in `src/main.js` rewrites
every `click` into an IPC message that's forwarded to the focused renderer,
which then re-runs its own copy of the handler. In the renderer, `app` (from
`src/menu.js`) is a stub object (`{name, getVersion}`) with no `quit()` method,
so the call threw/no-opped and the app never quit.

macOS was unaffected because the Quit item is spliced out of the File menu and
replaced with the native `{role: 'quit'}` there.

## Fix

Route Quit through `clickMain`, the existing mechanism used by "New Window" for
actions that must run in the main process:

- `src/menu.js`: change the Quit item from `click: () => app.quit()` to
  `clickMain: 'quit'`.
- `src/main.js`: add `quit: () => app.quit()` to the `clickMain` dispatch map
  used by `buildMenu()`.

With `clickMain`, the accelerator calls `app.quit()` directly in the main
process — no IPC roundtrip through the renderer's stub `app`.