### PR TITLE
Fix broken Score and Autoplay settings controls (#1026)

### DIFF
--- a/e2e/setting-controls.spec.js
+++ b/e2e/setting-controls.spec.js
@@ -1,0 +1,75 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+
+test.describe('Settings-backed Controls', () => {
+  test('Score drawer Area/Territory toggle switches the scoring method', async ({
+    page,
+  }) => {
+    await page.evaluate(() => window.__sabaki.openDrawer('score'))
+    await page.waitForFunction(
+      () => window.__sabaki && window.__sabaki.state.openDrawer === 'score',
+    )
+    await page.waitForSelector('#score .tab-bar li:nth-child(1) a', {
+      state: 'attached',
+    })
+
+    // Default scoring.method is 'territory'.
+    expect(await page.evaluate(() => window.__sabaki.state.scoringMethod)).toBe(
+      'territory',
+    )
+
+    // Activate the "Area" tab (first item in the score drawer's tab bar).
+    await page.evaluate(() =>
+      document.querySelector('#score .tab-bar li:nth-child(1) a').click(),
+    )
+    await page.waitForFunction(
+      () => window.__sabaki.state.scoringMethod === 'area',
+      {timeout: 5000},
+    )
+    expect(await page.evaluate(() => window.__sabaki.state.scoringMethod)).toBe(
+      'area',
+    )
+
+    // Activate the "Territory" tab to confirm the control works both ways.
+    await page.evaluate(() =>
+      document.querySelector('#score .tab-bar li:nth-child(2) a').click(),
+    )
+    await page.waitForFunction(
+      () => window.__sabaki.state.scoringMethod === 'territory',
+      {timeout: 5000},
+    )
+    expect(await page.evaluate(() => window.__sabaki.state.scoringMethod)).toBe(
+      'territory',
+    )
+  })
+
+  test('Autoplay seconds-per-move slider persists its value', async ({
+    page,
+  }) => {
+    await page.evaluate(() => window.__sabaki.setMode('autoplay'))
+    await page.waitForFunction(
+      () => window.__sabaki && window.__sabaki.state.mode === 'autoplay',
+    )
+    await page.waitForSelector('#autoplay input[type=number]', {
+      state: 'attached',
+    })
+
+    // Default autoplay.sec_per_move is 1; change it to a distinct value.
+    await page.evaluate(() => {
+      let input = document.querySelector('#autoplay input[type=number]')
+      input.value = '7'
+      input.dispatchEvent(new Event('input', {bubbles: true}))
+      input.dispatchEvent(new Event('change', {bubbles: true}))
+    })
+
+    await page.waitForFunction(
+      () => window.sabaki.setting.get('autoplay.sec_per_move') === 7,
+      {timeout: 5000},
+    )
+    expect(
+      await page.evaluate(() =>
+        window.sabaki.setting.get('autoplay.sec_per_move'),
+      ),
+    ).toBe(7)
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,5 +34,10 @@ module.exports = defineConfig({
       testMatch: /node-menu\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'settings',
+      testMatch: /setting-controls\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/bars/AutoplayBar.js
+++ b/src/components/bars/AutoplayBar.js
@@ -8,7 +8,10 @@ import i18n from '../../i18n.js'
 import Bar from './Bar.js'
 
 const t = i18n.context('AutoplayBar')
-const setting = {get: (key) => window.sabaki.setting.get(key)}
+const setting = {
+  get: (key) => window.sabaki.setting.get(key),
+  set: (key, value) => window.sabaki.setting.set(key, value),
+}
 
 let maxSecPerMove = setting.get('autoplay.max_sec_per_move')
 let secondsPerMove = setting.get('autoplay.sec_per_move')
@@ -41,9 +44,9 @@ export default class AutoplayBar extends Component {
           secondsPerMove: value,
           secondsPerMoveInput: value,
         })
-      }
 
-      setting.set('autoplay.sec_per_move', this.state.secondsPerMove)
+        setting.set('autoplay.sec_per_move', value)
+      }
     }
 
     this.handlePlayButtonClick = () => {

--- a/src/components/drawers/ScoreDrawer.js
+++ b/src/components/drawers/ScoreDrawer.js
@@ -8,7 +8,10 @@ import {noop, getScore} from '../../modules/helper.js'
 import Drawer from './Drawer.js'
 
 const t = i18n.context('ScoreDrawer')
-const setting = {get: (key) => window.sabaki.setting.get(key)}
+const setting = {
+  get: (key) => window.sabaki.setting.get(key),
+  set: (key, value) => window.sabaki.setting.set(key, value),
+}
 
 class ScoreRow extends Component {
   render({method, score, komi, handicap, sign}) {


### PR DESCRIPTION
Fixes #1026.

## Problem

The renderer migration off `@electron/remote` (commit `55a42d64`) replaced the settings module with per-component shims backed by `window.sabaki.setting`. Two components got a **get-only** shim while still calling `setting.set(...)`, so the calls reference an undefined method and the controls silently no-op:

- **Score drawer** — Area/Territory toggle never switched the scoring method.
- **Autoplay bar** — seconds-per-move slider never persisted its value.

## Fix

- Add `set` to both shims to match the rest of the codebase.
- **Additional fix (beyond the issue):** while adding an E2E test for the autoplay slider, a second, tightly-coupled bug surfaced in the same handler — it persisted `this.state.secondsPerMove`, which is stale immediately after the async `setState`, so even with a working shim the slider saved the *previous* value. It now persists the freshly clamped `value` directly, and only writes the setting when the input is valid.

## Tests

Added `e2e/setting-controls.spec.js` (new `settings` Playwright project, following the existing per-feature spec convention) that exercises both controls and asserts the setting change is applied. Verified test-first: both tests fail on `master` and pass with this change. Existing unit tests (65) and prettier both pass.
