### PR TITLE
Upgrade @primer/octicons 9 → 19 (with icon path migration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@mariotacke/color-thief": "^3.0.1",
-        "@primer/octicons": "^9.6.0",
+        "@primer/octicons": "^19.29.1",
         "@sabaki/boardmatcher": "^1.2.0",
         "@sabaki/deadstones": "^2.1.2",
         "@sabaki/go-board": "^1.4.1",
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@primer/octicons": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.6.0.tgz",
-      "integrity": "sha512-B5Wzk5izRXXz0JqEXJkVUtqhCXSpUKgqYkVwegMkp5sziBW+ksd9LPbONlCWyyLODwf9GsI2sBXekR7m+JJDBw==",
+      "version": "19.29.1",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.29.1.tgz",
+      "integrity": "sha512-XVRArUP8bN+IEjfNQSquXAJinVqAWRx36sVvhN5VzC+gOLfbx16EfFFvcFhSVaqQJ+57PjBrbj75oqm8VlOoYQ==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@mariotacke/color-thief": "^3.0.1",
-    "@primer/octicons": "^9.6.0",
+    "@primer/octicons": "^19.29.1",
     "@sabaki/boardmatcher": "^1.2.0",
     "@sabaki/deadstones": "^2.1.2",
     "@sabaki/go-board": "^1.4.1",

--- a/src/components/ToolBar.js
+++ b/src/components/ToolBar.js
@@ -37,7 +37,7 @@ export class ToolBarButton extends Component {
           h('img', {
             class: 'dropdown',
             height: 8,
-            src: './node_modules/@primer/octicons/build/svg/triangle-down.svg',
+            src: './node_modules/@primer/octicons/build/svg/triangle-down-16.svg',
             alt: '',
           }),
       ),

--- a/src/components/bars/FindBar.js
+++ b/src/components/bars/FindBar.js
@@ -54,7 +54,7 @@ export default class FindBar extends Component {
           'button',
           {class: 'next', onClick: this.handleButtonClick},
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/chevron-down.svg',
+            src: './node_modules/@primer/octicons/build/svg/chevron-down-16.svg',
             height: 20,
             alt: t('Next'),
           }),
@@ -63,7 +63,7 @@ export default class FindBar extends Component {
           'button',
           {class: 'prev', onClick: this.handleButtonClick},
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/chevron-up.svg',
+            src: './node_modules/@primer/octicons/build/svg/chevron-up-16.svg',
             height: 20,
             alt: t('Previous'),
           }),

--- a/src/components/bars/PlayBar.js
+++ b/src/components/bars/PlayBar.js
@@ -207,7 +207,7 @@ export default class PlayBar extends Component {
           onClick: this.handleMenuClick,
         },
         h('img', {
-          src: './node_modules/@primer/octicons/build/svg/three-bars.svg',
+          src: './node_modules/@primer/octicons/build/svg/three-bars-16.svg',
           height: 22,
         }),
       ),

--- a/src/components/drawers/AdvancedPropertiesDrawer.js
+++ b/src/components/drawers/AdvancedPropertiesDrawer.js
@@ -92,7 +92,9 @@ class PropertyItem extends Component {
               onClick: this.handleRemoveButtonClick,
             },
 
-            h('img', {src: './node_modules/@primer/octicons/build/svg/x.svg'}),
+            h('img', {
+              src: './node_modules/@primer/octicons/build/svg/x-16.svg',
+            }),
           ),
       ),
     )

--- a/src/components/drawers/InfoDrawer.js
+++ b/src/components/drawers/InfoDrawer.js
@@ -447,7 +447,7 @@ export default class InfoDrawer extends Component {
 
             h('img', {
               tabIndex: 0,
-              src: './node_modules/@primer/octicons/build/svg/chevron-down.svg',
+              src: './node_modules/@primer/octicons/build/svg/chevron-down-16.svg',
               width: 16,
               height: 16,
               class: classNames({menu: true, active: syncerEngines[0] != null}),
@@ -504,7 +504,7 @@ export default class InfoDrawer extends Component {
 
           h('img', {
             tabIndex: 0,
-            src: './node_modules/@primer/octicons/build/svg/chevron-down.svg',
+            src: './node_modules/@primer/octicons/build/svg/chevron-down-16.svg',
             width: 16,
             height: 16,
             class: classNames({menu: true, active: syncerEngines[1] != null}),

--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -387,7 +387,7 @@ class PathInputItem extends Component {
             onClick: this.handleBrowseButtonClick,
           },
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/file-directory.svg',
+            src: './node_modules/@primer/octicons/build/svg/file-directory-16.svg',
             title: t('Browse…'),
             height: 14,
           }),
@@ -401,7 +401,7 @@ class PathInputItem extends Component {
             'a',
             {class: 'invalid'},
             h('img', {
-              src: './node_modules/@primer/octicons/build/svg/alert.svg',
+              src: './node_modules/@primer/octicons/build/svg/alert-16.svg',
               title: this.props.chooseDirectory
                 ? t('Directory not found')
                 : t('File not found'),
@@ -655,7 +655,7 @@ class EngineItem extends Component {
             onClick: this.handleRemoveButtonClick,
           },
 
-          h('img', {src: './node_modules/@primer/octicons/build/svg/x.svg'}),
+          h('img', {src: './node_modules/@primer/octicons/build/svg/x-16.svg'}),
         ),
         h('input', {
           type: 'text',
@@ -677,7 +677,7 @@ class EngineItem extends Component {
           },
 
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/file-directory.svg',
+            src: './node_modules/@primer/octicons/build/svg/file-directory-16.svg',
           }),
         ),
         h('input', {

--- a/src/components/sidebars/CommentBox.js
+++ b/src/components/sidebars/CommentBox.js
@@ -140,7 +140,7 @@ class CommentTitle extends Component {
           },
 
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/question.svg',
+            src: './node_modules/@primer/octicons/build/svg/question-16.svg',
             width: 16,
             height: 16,
           }),
@@ -194,7 +194,7 @@ class CommentTitle extends Component {
       }),
 
       h('img', {
-        src: './node_modules/@primer/octicons/build/svg/pencil.svg',
+        src: './node_modules/@primer/octicons/build/svg/pencil-16.svg',
         class: 'edit-button',
         title: t('Edit'),
         width: 16,
@@ -351,7 +351,7 @@ export default class CommentBox extends Component {
           {class: 'header'},
           h('img', {
             ref: (el) => (this.menuButtonElement = el),
-            src: './node_modules/@primer/octicons/build/svg/chevron-down.svg',
+            src: './node_modules/@primer/octicons/build/svg/chevron-down-16.svg',
             width: 16,
             height: 16,
             onClick: this.handleMenuButtonClick,

--- a/src/components/sidebars/PeerList.js
+++ b/src/components/sidebars/PeerList.js
@@ -71,7 +71,7 @@ class EnginePeerListItem extends Component {
             },
             h('img', {
               src: `./node_modules/@primer/octicons/build/svg/${
-                !this.state.suspended ? 'triangle-right' : 'primitive-square'
+                !this.state.suspended ? 'triangle-right-16' : 'square-fill-16'
               }.svg`,
               alt: !this.state.suspended ? t('Running') : t('Stopped'),
             }),
@@ -89,7 +89,7 @@ class EnginePeerListItem extends Component {
             title: t('Analyzer'),
           },
           h('img', {
-            src: './node_modules/@primer/octicons/build/svg/pulse.svg',
+            src: './node_modules/@primer/octicons/build/svg/pulse-16.svg',
             alt: t('Analyzer'),
           }),
         ),
@@ -176,14 +176,14 @@ export class EnginePeerList extends Component {
         {},
 
         h(ToolBarButton, {
-          icon: './node_modules/@primer/octicons/build/svg/play.svg',
+          icon: './node_modules/@primer/octicons/build/svg/play-16.svg',
           tooltip: t('Attach Engine…'),
           menu: true,
           onClick: this.handleAttachEngineButtonClick,
         }),
 
         h(ToolBarButton, {
-          icon: './node_modules/@primer/octicons/build/svg/zap.svg',
+          icon: './node_modules/@primer/octicons/build/svg/zap-16.svg',
           tooltip: !engineGameOngoing
             ? t('Start Engine vs. Engine Game')
             : t('Stop Engine vs. Engine Game'),

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1799,7 +1799,7 @@ class Sabaki extends EventEmitter {
           internal: true,
           content: h('img', {
             class: 'icon',
-            src: './node_modules/@primer/octicons/build/svg/alert.svg',
+            src: './node_modules/@primer/octicons/build/svg/alert-16.svg',
             alt: t('Connection Failed'),
             title: t('Connection Failed'),
           }),

--- a/style/app.css
+++ b/style/app.css
@@ -138,7 +138,7 @@ form p, form ul li {
     left: 0;
     right: 0;
     bottom: 0;
-    background: url('../node_modules/@primer/octicons/build/svg/check.svg') center / auto 16px no-repeat;
+    background: url('../node_modules/@primer/octicons/build/svg/check-16.svg') center / auto 16px no-repeat;
     opacity: 0;
   }
   input[type="checkbox"]:checked::before {
@@ -164,7 +164,7 @@ form p, form ul li {
     right: 20px;
     top: 50%;
     margin-top: -8px;
-    background: url('../node_modules/@primer/octicons/build/svg/chevron-down.svg') center / auto 16px no-repeat;
+    background: url('../node_modules/@primer/octicons/build/svg/chevron-down-16.svg') center / auto 16px no-repeat;
     filter: invert(100%);
   }
   input:focus, button:focus, select:focus, textarea:focus {
@@ -229,10 +229,10 @@ form p, form ul li {
     -webkit-filter: invert(100%);
   }
   .pika-prev {
-    background-image: url('../node_modules/@primer/octicons/build/svg/chevron-left.svg');
+    background-image: url('../node_modules/@primer/octicons/build/svg/chevron-left-16.svg');
   }
   .pika-next {
-    background-image: url('../node_modules/@primer/octicons/build/svg/chevron-right.svg');
+    background-image: url('../node_modules/@primer/octicons/build/svg/chevron-right-16.svg');
 }
 
 .pika-table th {

--- a/style/index.css
+++ b/style/index.css
@@ -153,7 +153,7 @@ header {
     top: 0;
     height: 40px;
     width: 35px;
-    background: url('../node_modules/@primer/octicons/build/svg/x.svg') center / auto 21px no-repeat;
+    background: url('../node_modules/@primer/octicons/build/svg/x-16.svg') center / auto 21px no-repeat;
     opacity: .5;
   }
   #bar .bar .close:active { opacity: .7; }
@@ -281,14 +281,14 @@ header {
     top: 0;
     height: 40px;
     width: 35px;
-    background: url('../node_modules/@primer/octicons/build/svg/triangle-right.svg') center / 20px 20px no-repeat;
+    background: url('../node_modules/@primer/octicons/build/svg/triangle-right-16.svg') center / 20px 20px no-repeat;
     transform: translateX(-50%);
     filter: invert(100%);
     transition: background-image .2s, box-shadow .5s;
   }
   #autoplay.playing .play {
     background-color: rgba(255, 255, 255, .3);
-    background-image: url('../node_modules/@primer/octicons/build/svg/primitive-square.svg');
+    background-image: url('../node_modules/@primer/octicons/build/svg/square-fill-16.svg');
     box-shadow: 0 0 40px rgba(0, 0, 0, .5);
   }
   #autoplay .play:hover {


### PR DESCRIPTION
Supersedes #1001 — Dependabot's version-only bump, which would 404 **every** icon in the UI.

Between v9 and v19, octicons renamed all its SVG assets with size suffixes (`alert.svg` → `alert-16.svg`) and dropped the `primitive-*` family (`primitive-square` → `square-fill`). Sabaki loads octicons by **on-disk path** — JS `<img src>`, CSS `url()`, and the `build.files` bundle glob — so bumping the version alone breaks every icon. This PR does the version bump **and** the required path migration (~25 references across 11 JS + 2 CSS files, including the one dynamic `PeerList` ternary and the `primitive-square` → `square-fill` rename).

## Verification (Node 24, Electron 43)

- **All 17 referenced icon paths resolve** to real files in octicons 19 (deterministic check).
- **At runtime, every octicon loads** — `naturalWidth > 0`, **0 broken** across a 15-icon on-screen sample plus a 17-path in-renderer `Image()` probe against the packaged app.
- `npm test` (65 passing), `npm run build`, and e2e smoke (7/7) all green.