### PR TITLE
Quit properly on macOS instead of requiring multiple Cmd+Q (fixes #157)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -199,6 +199,10 @@ class App extends Component {
           gtplogger.close()
           this.closeWindow = true
           sabaki.window.close()
+        } else {
+          // User backed out of the close; clear any pending quit intent so a
+          // later ordinary window close still leaves the app running (macOS).
+          window.sabaki.app.cancelQuit()
         }
       })
     })

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const updater = require('./updater')
 
 let windows = []
 let openfile = null
+let isQuitting = false
 
 function newWindow(path) {
   let window = new BrowserWindow({
@@ -199,6 +200,12 @@ function setupIpcHandlers() {
   ipcMain.handle('app:getName', () => app.name)
   ipcMain.handle('app:getVersion', () => app.getVersion())
   ipcMain.handle('app:quit', () => app.quit())
+  // A renderer aborts an in-progress quit (e.g. the user cancelled the
+  // unsaved-changes prompt) so a later ordinary window close doesn't quit the
+  // app on macOS.
+  ipcMain.handle('app:cancelQuit', () => {
+    isQuitting = false
+  })
 
   // Window operations
   ipcMain.handle('window:setFullScreen', (e, f) => {
@@ -351,8 +358,17 @@ async function main() {
     app.disableHardwareAcceleration()
   }
 
+  // Track an explicit quit request (Cmd+Q / Quit menu) so that on macOS the app
+  // actually terminates once its windows close. The renderer's async
+  // beforeunload cancels the first close to run the save prompt, which aborts
+  // app.quit(); without this flag, window-all-closed then keeps the app alive,
+  // so the window vanishes but the process lingers (issue #157).
+  app.on('before-quit', () => {
+    isQuitting = true
+  })
+
   app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') {
+    if (process.platform !== 'darwin' || isQuitting) {
       app.quit()
     } else {
       buildMenu({disableAll: true})

--- a/src/preload.js
+++ b/src/preload.js
@@ -119,6 +119,7 @@ window.sabaki = {
     getName: () => ipcRenderer.invoke('app:getName'),
     getVersion: () => ipcRenderer.invoke('app:getVersion'),
     quit: () => ipcRenderer.invoke('app:quit'),
+    cancelQuit: () => ipcRenderer.invoke('app:cancelQuit'),
   },
 
   // Shell


### PR DESCRIPTION
On macOS, pressing ⌘Q or choosing Quit closed the window but left the process running, so the app only quit after several attempts. Fixes #157.

## Cause

Closing a window is intercepted in the renderer to run an async "save changes?" prompt (`App.js`, `beforeunload`): the first close is cancelled via `evt.returnValue`, the prompt runs, and only then is the window closed for real. That cancellation also aborts `app.quit()` — so on macOS, where `window-all-closed` deliberately keeps the app resident, the window disappears but the process stays alive. Windows and Linux quit from `window-all-closed`, which masked the problem there.

## Fix

Track the quit intent in the main process instead of inferring it from the window close:

- Set a flag on `before-quit`.
- In `window-all-closed`, quit on macOS too when that flag is set (behavior is otherwise unchanged: quit on Windows/Linux, stay resident on macOS).
- Reset the flag if the user backs out of the save prompt, so an ordinary window close still leaves the app running per the macOS convention.

## Testing (macOS)

- ⌘Q on a clean board quits immediately, in a single press.
- ⌘Q with unsaved changes: Save / Don't Save quits; Cancel keeps the app open, and a subsequent ordinary window close still leaves it resident.
- Closing the last window without quitting still keeps the app running, and reactivating from the dock reopens a window.

No behavior change on Windows or Linux.
