### PR TITLE
Add always-show-result preference

### DIFF
--- a/src/components/drawers/PreferencesDrawer.js
+++ b/src/components/drawers/PreferencesDrawer.js
@@ -155,6 +155,10 @@ class GeneralTab extends Component {
           id: 'view.animated_stone_placement',
           text: t('Animate fuzzy placement'),
         }),
+        h(PreferencesItem, {
+          id: 'app.always_show_result',
+          text: t('Always show game result'),
+        }),
 
         h(
           'li',


### PR DESCRIPTION
Preferences drawer: Added a boolean option to always show the game result.

The `app.always_show_result` logic already existed; this commit simply exposes this setting as a Preference item.