### PR TITLE
Bump @sabaki/gtp to ^3.1.0 to fix .bat/.cmd engines on Windows (#1037)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sabaki/boardmatcher": "^1.2.0",
         "@sabaki/deadstones": "^2.1.2",
         "@sabaki/go-board": "^1.4.1",
-        "@sabaki/gtp": "^3.0.0",
+        "@sabaki/gtp": "^3.1.0",
         "@sabaki/i18n": "0.51.1-1",
         "@sabaki/immutable-gametree": "^1.9.4",
         "@sabaki/influence": "^1.2.2",
@@ -1275,9 +1275,9 @@
       "license": "MIT"
     },
     "node_modules/@sabaki/gtp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.0.0.tgz",
-      "integrity": "sha512-faMAB9pTz2lIPUQz0dNV5IcA+bagRZYldGdCr7/Bl7dqJ3A/4FkspqrcTkM1LgZZ0xctbQRKedkpqhkORitw6A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.1.0.tgz",
+      "integrity": "sha512-xNGoraSlFcmvT48zeo/UR1V0nmbNtcdhCX6YRrJERPQQLf9tKKZ6VG72aFogNT+88apiJZJKiIHE9Z70+9iDAw==",
       "license": "MIT"
     },
     "node_modules/@sabaki/i18n": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@sabaki/boardmatcher": "^1.2.0",
     "@sabaki/deadstones": "^2.1.2",
     "@sabaki/go-board": "^1.4.1",
-    "@sabaki/gtp": "^3.0.0",
+    "@sabaki/gtp": "^3.1.0",
     "@sabaki/i18n": "0.51.1-1",
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",


### PR DESCRIPTION
Fixes #1037. On the Electron 43 / Node 24 build, engines configured as a `.bat`/`.cmd` wrapper stopped attaching with no error: Node 24 refuses to `spawn` a `.bat`/`.cmd` on Windows without a shell (CVE-2024-27980), and `@sabaki/gtp`'s `Controller` spawned the path directly.

The actual fix is in `@sabaki/gtp` 3.1.0 (SabakiHQ/gtp#10): on Windows it routes `.bat`/`.cmd` engines through `cmd.exe` with correctly quoted arguments, and leaves every other platform's spawn path unchanged. This PR just bumps the dependency to pull it in.

@jun63cn confirmed the fix on their Windows build (Pachi/Sayuri/minigo/PhoenixGo, all `.bat` wrappers). Unit tests pass locally; the engine e2e exercises the normal spawn path.
