### PR TITLE
fix: prevent argv flags and app path from being treated as open file

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ const {resolve} = require('path')
 const i18n = require('./i18n')
 const setting = require('./setting')
 const updater = require('./updater')
+const {getOpenFileFromArgv} = require('./modules/utils')
 
 let windows = []
 let openfile = null
@@ -418,18 +419,8 @@ async function main() {
 
   setupIpcHandlers()
 
-  if (!openfile && process.argv.length >= 2) {
-    // Ignore Chromium flags and Electron entry
-    let args = process.argv.slice(1).filter(arg =>
-      !arg.startsWith('--') &&
-      arg !== '.' &&
-      !arg.endsWith('.asar') &&
-      !arg.endsWith('.asar/')
-    )
-
-    if (args.length > 0) {
-      openfile = args[0]
-    }
+  if (!openfile) {
+    openfile = getOpenFileFromArgv(process.argv)
   }
 
   newWindow(openfile)

--- a/src/main.js
+++ b/src/main.js
@@ -419,14 +419,16 @@ async function main() {
   setupIpcHandlers()
 
   if (!openfile && process.argv.length >= 2) {
-    if (
-      !['electron.exe', 'electron'].some((x) =>
-        process.argv[0].toLowerCase().endsWith(x),
-      )
-    ) {
-      openfile = process.argv[1]
-    } else if (process.argv.length >= 3) {
-      openfile = process.argv[2]
+    // Ignore Chromium flags and Electron entry
+    let args = process.argv.slice(1).filter(arg =>
+      !arg.startsWith('--') &&
+      arg !== '.' &&
+      !arg.endsWith('.asar') &&
+      !arg.endsWith('.asar/')
+    )
+
+    if (args.length > 0) {
+      openfile = args[0]
     }
   }
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -127,3 +127,24 @@ export function getScore(board, areaMap, {komi = 0, handicap = 0} = {}) {
 export function cycleAreaValue(value, steps) {
   return ((value + 1 + steps) % 3) - 1
 }
+
+// The file to open that was passed on the command line at launch, or null.
+// `argv[0]` is the binary; everything that isn't a file to open is filtered out:
+// flags (any leading '-', so Chromium's '--no-sandbox' and macOS's '-psn_...'
+// both go), the dev-mode entry '.', and the packaged-app entry ('*.asar'). Some
+// Linux launchers (snap, AppImage '.desktop' files) inject flags and ship a
+// renamed binary, so a binary-name or argv-position heuristic isn't reliable --
+// filter by content instead. Returns the first surviving argument. See #954.
+export function getOpenFileFromArgv(argv) {
+  let files = argv
+    .slice(1)
+    .filter(
+      (arg) =>
+        !arg.startsWith('-') &&
+        arg !== '.' &&
+        !arg.endsWith('.asar') &&
+        !arg.endsWith('.asar/'),
+    )
+
+  return files.length > 0 ? files[0] : null
+}

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 
-import {cycleAreaValue} from '../src/modules/utils.js'
+import {cycleAreaValue, getOpenFileFromArgv} from '../src/modules/utils.js'
 
 // cycleAreaValue backs the manual territory overrides in scoring/estimator mode.
 // Area values are -1 (white) / 0 (neutral) / 1 (black), and `steps` advances a
@@ -23,5 +23,64 @@ describe('cycleAreaValue', () => {
       assert.strictEqual(cycleAreaValue(base, 3), base)
       assert.strictEqual(cycleAreaValue(base, 6), base)
     }
+  })
+})
+
+// Backs the launch-time "open this file" handling in main.js. argv[0] is always
+// the binary; the file to open (if any) is somewhere in the rest, mixed with
+// flags and the app entry point. See issue #954.
+describe('getOpenFileFromArgv', () => {
+  const dev = '/opt/electron' // dev: `electron . [flags] [file]`
+  const devRenamed = '/usr/bin/electron42' // some Linux distros rename it
+  const macApp = '/Applications/Sabaki.app/Contents/MacOS/Sabaki'
+  const winExe = 'C:\\Program Files\\Sabaki\\Sabaki.exe'
+  const linuxBin = '/opt/Sabaki/sabaki'
+  const file = '/home/u/game.sgf'
+
+  it('returns null when only the binary is present', () => {
+    assert.strictEqual(getOpenFileFromArgv([macApp]), null)
+    assert.strictEqual(getOpenFileFromArgv([]), null)
+  })
+
+  it('reads a file passed to a packaged app', () => {
+    assert.strictEqual(getOpenFileFromArgv([winExe, file]), file)
+    assert.strictEqual(getOpenFileFromArgv([macApp, file]), file)
+    assert.strictEqual(getOpenFileFromArgv([linuxBin, file]), file)
+  })
+
+  it('skips the dev-mode "." entry', () => {
+    assert.strictEqual(getOpenFileFromArgv([dev, '.']), null)
+    assert.strictEqual(getOpenFileFromArgv([dev, '.', file]), file)
+  })
+
+  it('works regardless of the binary name (renamed Linux electron)', () => {
+    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.', file]), file)
+    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.']), null)
+  })
+
+  it('ignores injected flags (snap/AppImage --no-sandbox, #954)', () => {
+    assert.strictEqual(getOpenFileFromArgv([linuxBin, '--no-sandbox']), null)
+    assert.strictEqual(
+      getOpenFileFromArgv([linuxBin, '--no-sandbox', file]),
+      file,
+    )
+    assert.strictEqual(getOpenFileFromArgv([dev, '.', '--inspect', file]), file)
+    assert.strictEqual(
+      getOpenFileFromArgv([winExe, '--disable-gpu', file]),
+      file,
+    )
+  })
+
+  it('ignores single-dash args (e.g. macOS -psn_)', () => {
+    assert.strictEqual(getOpenFileFromArgv([macApp, '-psn_0_12345']), null)
+    assert.strictEqual(
+      getOpenFileFromArgv([macApp, '-psn_0_12345', file]),
+      file,
+    )
+  })
+
+  it('skips the packaged .asar entry', () => {
+    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar', file]), file)
+    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar/']), null)
   })
 })


### PR DESCRIPTION
The old argv parsing checked whether process.argv[0] ended with "electron" or "electron.exe" to distinguish dev mode from packaged mode. On Linux distributions where the Electron binary can be named electron42, electron32, etc., this check fails, causing the code to fall into the wrong branch and treat the app.asar path or Chromium flags (--no-sandbox, --disable-gpu, etc.) as a file to open.

Replace the fragile binary-name check with robust content-based filtering: filter out internal --flags, as well as the app entry paths ("." for dev mode, or ".asar" for packaged mode). The first remaining argument (if any) is the actual file to open.

Fix #954