### PR TITLE
Bump @sabaki/deadstones to ^2.2.0 (single-eye dead-stone detection)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mariotacke/color-thief": "^3.0.1",
         "@primer/octicons": "^19.29.1",
         "@sabaki/boardmatcher": "^1.2.0",
-        "@sabaki/deadstones": "^2.1.2",
+        "@sabaki/deadstones": "^2.2.0",
         "@sabaki/go-board": "^1.4.1",
         "@sabaki/gtp": "^3.1.0",
         "@sabaki/i18n": "0.51.1-1",
@@ -1263,9 +1263,9 @@
       "license": "MIT"
     },
     "node_modules/@sabaki/deadstones": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@sabaki/deadstones/-/deadstones-2.1.2.tgz",
-      "integrity": "sha512-C2lmvm6VEFwZwRd8rNSYxVikVXCBmy3MYsC6ZdmexEuH3q9Ha/oKfGSZEczI3kZLz/64vZ7s2ST/wJHpR193lQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sabaki/deadstones/-/deadstones-2.2.0.tgz",
+      "integrity": "sha512-Sj7O8qShY34S4Cpa4ktAp/XP9cCTldqoUBHl9qcmbTK+zc35FtjBoDQ6/Q5KBSzbJz9dlMTfsF1GTsPwV5UlDA==",
       "license": "MIT"
     },
     "node_modules/@sabaki/go-board": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@mariotacke/color-thief": "^3.0.1",
     "@primer/octicons": "^19.29.1",
     "@sabaki/boardmatcher": "^1.2.0",
-    "@sabaki/deadstones": "^2.1.2",
+    "@sabaki/deadstones": "^2.2.0",
     "@sabaki/go-board": "^1.4.1",
     "@sabaki/gtp": "^3.1.0",
     "@sabaki/i18n": "0.51.1-1",


### PR DESCRIPTION
Picks up `@sabaki/deadstones` 2.2.0.

The main user-facing win: dead groups with a single eye are now marked dead in Score / Estimator mode. Before, a lone stone filling the group's last eye was treated as an illegal move, so the group could never be captured in a playout and read as alive at any iteration count (SabakiHQ/deadstones#10, SabakiHQ/deadstones#7).

2.2.0 also modernizes the package's build (wasm-bindgen 0.2.48 -> 0.2.126, so it builds on current Rust) and adds browser/ESM entry points, but none of that changes how Sabaki consumes it -- the `useFetch` loading path is unchanged.

Declared range `^2.1.2` -> `^2.2.0`; lockfile updated. `npm test` and the scoring e2e pass.
