### PR TITLE
Bump @sabaki/sgf to ^3.5.0 (read Shift-JIS/legacy-encoded SGF files)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@sabaki/i18n": "0.51.1-1",
         "@sabaki/immutable-gametree": "^1.9.4",
         "@sabaki/influence": "^1.2.2",
-        "@sabaki/sgf": "^3.4.7",
+        "@sabaki/sgf": "^3.5.0",
         "@sabaki/shudan": "^1.7.1",
         "argv-split": "^3.2.1",
         "classnames": "^2.2.6",
@@ -1299,9 +1299,9 @@
       "license": "MIT"
     },
     "node_modules/@sabaki/sgf": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@sabaki/sgf/-/sgf-3.4.7.tgz",
-      "integrity": "sha512-513CQMEejYVqaIKWK+P3AL1TXv2cqdUVOI+3mJDGcDEw5fWlz8puEYn+aQrGjnxJrn5XUUX0fefndEJbam65Sw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sabaki/sgf/-/sgf-3.5.0.tgz",
+      "integrity": "sha512-KAkgUFe/A7jc4xZtUBAhDeH6IqPYMHoKts6nXhYHNCvBud4DChJ9EpKLDCeWuVijb960FCXvhBfAy6OkdZZpfA==",
       "license": "MIT",
       "dependencies": {
         "doken": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@sabaki/i18n": "0.51.1-1",
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",
-    "@sabaki/sgf": "^3.4.7",
+    "@sabaki/sgf": "^3.5.0",
     "@sabaki/shudan": "^1.7.1",
     "argv-split": "^3.2.1",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Picks up `@sabaki/sgf` 3.5.0, which recovers the encoding of non-UTF-8 SGF files that have no `CA[]` property.

Nihon Ki-in Shift-JIS kifu (e.g. downloaded from goratings.org) currently fail to open with "This file is unreadable", because `@sabaki/sgf`'s tokenizer couldn't determine the charset and threw. 3.5.0 detects and recovers Shift-JIS (and EUC-KR, GB18030, Big5, windows-1251) even with no `CA[]` declaration, so the game opens and its player names / event render correctly.

Verified the reported file opens with the right metadata (`PW[党毅飛]`, event intact); `npm test` is green.

Fixes #1029
