### PR TITLE
Fix SGF label cleanup (#881) and compressed point-list editing (#856)

### DIFF
--- a/e2e/edit-compressed-points.spec.js
+++ b/e2e/edit-compressed-points.spec.js
@@ -1,0 +1,55 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {waitForRender} = require('./helpers')
+
+// #856: editing a node that carries compressed AB/AW/AE point lists used to
+// mangle them. useTool() resolves the compressed lists into individual points,
+// but the flatten was broken (a `.reduce` with no seed spread only the first
+// sublist and nested the rest), producing comma-joined junk properties. Placing
+// any setup stone on such a node should leave AB as clean single-point idents.
+
+// A single root node carrying a compressed AB frame and nothing else: useTool
+// only edits a setup node in place when it has no B/W and no children, so the
+// node under test must be childless.
+const SGF = '(;AB[ba:ra][ab:ar][sb:sr][bs:rs])'
+
+test.describe('editing compressed point lists (#856)', () => {
+  test('resolves a compressed AB list into clean single points', async ({
+    page,
+  }) => {
+    await page.evaluate((sgf) => window.__sabaki.loadContent(sgf, 'sgf'), SGF)
+    await page.waitForFunction(
+      () => {
+        const s = window.__sabaki
+        if (!s) return false
+        const tree = s.state.gameTrees[s.state.gameIndex]
+        return tree && tree.root.data.AB != null
+      },
+      {timeout: 10000},
+    )
+    await page.evaluate(() => window.__sabaki.setMode('edit'))
+    await waitForRender(page)
+
+    // Placing a black setup stone on an empty vertex triggers the
+    // compressed-list resolution on the root's AB.
+    await page.evaluate(() => window.__sabaki.useTool('stone_1', [3, 3]))
+    await waitForRender(page)
+
+    const ab = await page.evaluate(() => {
+      const s = window.__sabaki
+      const tree = s.state.gameTrees[s.state.gameIndex]
+      return tree.root.data.AB
+    })
+
+    expect(Array.isArray(ab)).toBe(true)
+    // Every entry must be a clean 2-char point: no leftover ':' ranges and no
+    // comma-joined nested arrays.
+    for (const point of ab) {
+      expect(point).toMatch(/^[a-zA-Z]{2}$/)
+    }
+    // The frame fully expanded (well past the 4 original compressed ranges) and
+    // the newly placed stone at [3, 3] ('dd') is present.
+    expect(ab.length).toBeGreaterThan(4)
+    expect(ab).toContain('dd')
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -59,5 +59,10 @@ module.exports = defineConfig({
       testMatch: /analysis-value-display\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'edit-compressed-points',
+      testMatch: /edit-compressed-points\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/drawers/CleanMarkupDrawer.js
+++ b/src/components/drawers/CleanMarkupDrawer.js
@@ -3,6 +3,7 @@ import {h, Component} from 'preact'
 import i18n from '../../i18n.js'
 import sabaki from '../../modules/sabaki.js'
 import {wait, popupMenu} from '../../modules/helper.js'
+import {markupCleanupProperties} from '../../modules/utils.js'
 
 import Drawer from './Drawer.js'
 
@@ -56,19 +57,7 @@ export default class CleanMarkupDrawer extends Component {
       let doRemove = async (work) => {
         sabaki.setBusy(true)
 
-        let data = {
-          cross: ['MA'],
-          triangle: ['TR'],
-          square: ['SQ'],
-          circle: ['CR'],
-          line: ['LN'],
-          arrow: ['AR'],
-          label: ['LB'],
-          comments: ['C', 'N'],
-          annotations: ['DM', 'GB', 'GW', 'UC', 'BM', 'DO', 'IT', 'TE'],
-          hotspots: ['HO'],
-          winrate: ['SBKV', 'SBKS'],
-        }
+        let data = markupCleanupProperties
 
         let properties = Object.keys(data)
           .filter((id) => setting.get(`cleanmarkup.${id}`))

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1373,7 +1373,7 @@ class Sabaki extends EventEmitter {
                 .map((value) =>
                   sgf.parseCompressedVertices(value).map(sgf.stringifyVertex),
                 )
-                .reduce((list, x) => [...list, x]),
+                .flat(),
             )
           }
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -148,3 +148,20 @@ export function getOpenFileFromArgv(argv) {
 
   return files.length > 0 ? files[0] : null
 }
+
+// Maps each Clean Markup category to the SGF properties it strips. `label`
+// covers both modern LB[] labels and old-style L[] labels (FF[3]), which Sabaki
+// still reads and renders (see gametree.js), so cleaning labels must remove both.
+export const markupCleanupProperties = {
+  cross: ['MA'],
+  triangle: ['TR'],
+  square: ['SQ'],
+  circle: ['CR'],
+  line: ['LN'],
+  arrow: ['AR'],
+  label: ['LB', 'L'],
+  comments: ['C', 'N'],
+  annotations: ['DM', 'GB', 'GW', 'UC', 'BM', 'DO', 'IT', 'TE'],
+  hotspots: ['HO'],
+  winrate: ['SBKV', 'SBKS'],
+}

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -1,6 +1,10 @@
 import assert from 'assert'
 
-import {cycleAreaValue, getOpenFileFromArgv} from '../src/modules/utils.js'
+import {
+  cycleAreaValue,
+  getOpenFileFromArgv,
+  markupCleanupProperties,
+} from '../src/modules/utils.js'
 
 // cycleAreaValue backs the manual territory overrides in scoring/estimator mode.
 // Area values are -1 (white) / 0 (neutral) / 1 (black), and `steps` advances a
@@ -82,5 +86,27 @@ describe('getOpenFileFromArgv', () => {
   it('skips the packaged .asar entry', () => {
     assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar', file]), file)
     assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar/']), null)
+  })
+})
+
+// Backs Tools -> Clean markup. The label category must strip old-style L[]
+// labels (FF[3]) as well as modern LB[], since Sabaki reads and renders both;
+// see #881.
+describe('markupCleanupProperties', () => {
+  it('cleans both old-style L[] and modern LB[] labels', () => {
+    assert.deepStrictEqual(markupCleanupProperties.label, ['LB', 'L'])
+  })
+
+  it('maps every category to a non-empty list of property idents', () => {
+    for (let [category, props] of Object.entries(markupCleanupProperties)) {
+      assert.ok(
+        Array.isArray(props) && props.length > 0,
+        `${category} should map to a non-empty array`,
+      )
+      assert.ok(
+        props.every((p) => typeof p === 'string' && /^[A-Z]+$/.test(p)),
+        `${category} props should be SGF idents`,
+      )
+    }
   })
 })


### PR DESCRIPTION
Two SGF-editing fixes for the v0.60.1 milestone.

**#881 -- Clean Markup leaves old-style `L[]` labels.** Tools > Clean markup > Label markers only removed `LB[]`, so old-style `L[]` labels (FF[3], which Sabaki still reads and renders via `gametree.js`) survived the cleanup. Moved the category -> property map out of the drawer into `utils.js` as `markupCleanupProperties` so it's unit-testable, and `label` now covers both `LB` and `L`.

**#856 -- compressed point lists corrupt on edit.** `useTool` resolves compressed `AB`/`AW`/`AE` lists into individual points before applying an edit, but flattened with `.reduce((list, x) => [...list, x])` and no seed: that spreads only the first sublist and appends the rest as nested arrays, which stringify into comma-joined junk properties. Replaced with `.flat()`. Added an e2e that loads `(;AB[ba:ra][ab:ar][sb:sr][bs:rs])`, places a setup stone to trigger resolution, and asserts every entry is a clean 2-char point ident (verified it fails on the old `.reduce`).

`npm test` (88 passing) plus the new `edit-compressed-points` e2e are green.

Fixes #881
Fixes #856
