### PR TITLE
Engine responds to a human pass (#857); no uncaught rejection on engine stop (#720)

### DIFF
--- a/e2e/engine.spec.js
+++ b/e2e/engine.spec.js
@@ -92,6 +92,41 @@ test.describe('GTP Engine Integration Tests', () => {
     await detachAndWait(page, syncerIds)
   })
 
+  test('engine responds to a human pass (#857)', async ({page}) => {
+    const syncerIds = await attachAndWaitForEngines(page, [
+      {name: 'WhiteEngine', path: process.execPath, args: enginePath},
+    ])
+
+    // Assign the engine to white, so a black pass should draw a white response.
+    await page.evaluate((id) => {
+      window.__sabaki.setState({whiteEngineSyncerId: id})
+    }, syncerIds[0])
+
+    // Black passes through the same code path the Pass button and menu use.
+    await page.evaluate(() => window.__sabaki.makePass())
+
+    // The engine must generate a move in response: the pass is depth 1 and the
+    // engine's reply is depth 2. Before the fix, passing never triggered it.
+    await page.waitForFunction(
+      () => {
+        const s = window.__sabaki
+        const tree = s.state.gameTrees[s.state.gameIndex]
+        let pos = s.state.treePosition
+        let depth = 0
+        while (pos !== tree.root.id) {
+          pos = tree.get(pos).parentId
+          depth++
+        }
+        return depth >= 2
+      },
+      {timeout: 10000},
+    )
+
+    expect(await getTreeDepth(page)).toBeGreaterThanOrEqual(2)
+
+    await detachAndWait(page, syncerIds)
+  })
+
   test('bot-vs-bot game completes', async ({page}) => {
     const syncerIds = await attachAndWaitForEngines(page, [
       {name: 'BlackEngine', path: process.execPath, args: enginePath},

--- a/src/components/bars/PlayBar.js
+++ b/src/components/bars/PlayBar.js
@@ -33,7 +33,7 @@ export default class PlayBar extends Component {
         [
           {
             label: t('&Pass'),
-            click: () => sabaki.makeMove([-1, -1]),
+            click: () => sabaki.makePass(),
           },
           {
             label: t('&Resign'),

--- a/src/menu.js
+++ b/src/menu.js
@@ -154,7 +154,7 @@ exports.get = function (props = {}) {
         {
           label: i18n.t('menu.play', '&Pass'),
           accelerator: 'CmdOrCtrl+P',
-          click: () => sabaki.makeMove([-1, -1]),
+          click: () => sabaki.makePass(),
         },
         {
           label: i18n.t('menu.play', 'Resig&n'),

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -206,7 +206,15 @@ export default class EngineSyncer extends EventEmitter {
 
   async sendAbort() {
     if (this.controller.busy) {
-      await this.controller.sendCommand({name: 'protocol_version'})
+      try {
+        await this.controller.sendCommand({name: 'protocol_version'})
+      } catch (err) {
+        // Best-effort interrupt: if the engine has already stopped (e.g. it's
+        // being killed during shutdown) the command rejects with "GTP engine
+        // output has stopped". queueCommand()/sync() fire this without awaiting,
+        // so swallow it here rather than surface an unhandled rejection. See
+        // #720.
+      }
     }
   }
 

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1303,6 +1303,15 @@ class Sabaki extends EventEmitter {
     }
   }
 
+  makePass() {
+    // A pass is a play action, so mirror board-click behavior and let an
+    // attached engine respond to it -- unless an engine-vs-engine game is
+    // already driving the moves. See #857.
+    this.makeMove([-1, -1], {
+      generateEngineMove: this.state.engineGameOngoing == null,
+    })
+  }
+
   makeResign({player = null} = {}) {
     let {gameTrees, gameIndex, treePosition} = this.state
     let {currentPlayer} = this.inferredState


### PR DESCRIPTION
Two engine-handling fixes for the v0.60.1 milestone.

**#857 -- engine doesn't respond to a human pass.** A board click passes `generateEngineMove` so an attached engine replies to a human move, but the Pass button (PlayBar) and the Pass menu item both called `makeMove([-1, -1])` with no options, so a pass never triggered the engine; you had to hit "generate move" manually. Added a `makePass()` method that mirrors the board click (`generateEngineMove: engineGameOngoing == null`) and routed both Pass entry points through it. New engine e2e: assign the engine to white, black passes via `makePass()`, and the engine's reply advances the tree to depth 2 (verified it times out on the old no-flag path).

**#720 -- uncaught rejection when stopping an engine mid-match.** `queueCommand()`/`sync()` fire `sendAbort()` without awaiting it, and `sendAbort` awaits a `protocol_version` command that rejects with "GTP engine output has stopped" when the process is killed, so the rejection surfaced as an unhandled promise (the caller's try/catch can't catch a fire-and-forget promise). Wrapped the interrupt in try/catch: aborting a busy engine is best-effort, so a failed interrupt during shutdown is safe to ignore. Verified by inspection -- reproducing the exact stop-mid-match race deterministically in e2e isn't practical, and this is a straightforward fire-and-forget-rejection guard.

`npm test` (88) and the engine e2e suite (13, including the new pass test) are green.

Fixes #857
Fixes #720
