### PR TITLE
Keep SGF markup under move numbers (#965); ctrl+click coordinate sticks in comment box (#844)

### DIFF
--- a/e2e/comment-coordinate.spec.js
+++ b/e2e/comment-coordinate.spec.js
@@ -1,0 +1,55 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// #844: ctrl+click on an intersection in edit mode appends the coordinate to
+// the current node's comment. The comment textarea must refresh to show it;
+// before the fix the textarea (controlled by CommentBox's own state) kept the
+// stale value because it only re-synced when the tree position changed, so the
+// coordinate never appeared and the next blur committed the stale text back,
+// dropping it.
+
+const SGF = '(;GM[1]FF[4]CA[UTF-8]SZ[19];B[pd])'
+
+test.describe('ctrl+click coordinate into comment (#844)', () => {
+  test('refreshes the comment textarea with the clicked coordinate', async ({
+    page,
+  }) => {
+    await loadSgfStringAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+    await page.evaluate(() => window.__sabaki.setMode('edit'))
+    // Show the sidebar/comment box, as when editing a comment for real. Sidebar
+    // only re-renders (and so refreshes CommentBox) while it's visible, so an
+    // in-place comment change is invisible with the sidebar collapsed.
+    await page.evaluate(() =>
+      window.__sabaki.setState({showSidebar: true, showCommentBox: true}),
+    )
+    await waitForRender(page)
+
+    const textarea = page.locator('#properties textarea')
+    await textarea.waitFor({state: 'attached'})
+    // Let CommentBox's navigation debounce (graph.delay = 100ms) settle, so its
+    // trailing setState doesn't clobber what we add next.
+    await page.waitForTimeout(300)
+    expect((await textarea.inputValue()).trim()).toBe('')
+
+    // The coordinate the ctrl+click handler will compute for [3, 3].
+    const coord = await page.evaluate(() =>
+      window.__sabaki.inferredState.board.stringifyVertex([3, 3]),
+    )
+
+    await page.evaluate(() =>
+      window.__sabaki.clickVertex([3, 3], {ctrlKey: true}),
+    )
+
+    // Textarea reflects the coordinate (this is the fix).
+    await expect(textarea).toHaveValue(new RegExp(coord))
+    // ...and it's committed on the node.
+    const comment = await page.evaluate(() => {
+      const s = window.__sabaki
+      const tree = s.state.gameTrees[s.state.gameIndex]
+      return tree.get(s.state.treePosition).data.C[0]
+    })
+    expect(comment).toContain(coord)
+  })
+})

--- a/e2e/move-numbers.spec.js
+++ b/e2e/move-numbers.spec.js
@@ -12,9 +12,9 @@ const {
 // These drive the real Goban rendering and read the move-number labels that
 // @sabaki/shudan paints onto each vertex. Shudan sets the vertex element's
 // `title` attribute to the marker label, so a vertex numbered "3" produces a
-// `.shudan-vertex` with title="3". When move numbers are enabled the Goban
-// resets all other markers to null, so the only labelled vertices are the
-// numbered moves.
+// `.shudan-vertex` with title="3". Move numbers overwrite only the numbered
+// move vertices; other SGF markup (triangles, labels, ...) is preserved -- see
+// the #965 test below.
 
 // --- move-number helpers ---------------------------------------------------
 
@@ -127,6 +127,38 @@ test.describe('Move Numbering', () => {
       await setMoveNumbers(page, 'variation')
 
       expect(await moveNumberLabels(page)).toEqual([1, 2])
+    })
+
+    // #965: enabling move numbers used to wipe every marker on the board, so
+    // SGF triangles/squares/labels vanished. They must survive on the vertices
+    // that don't carry a number.
+    test('keeps SGF markup visible when move numbers are on (#965)', async ({
+      page,
+    }) => {
+      // One move at pd, plus markup on three other vertices.
+      await loadSgfStringAndWait(
+        page,
+        '(;GM[1]FF[4]CA[UTF-8]SZ[19];B[pd]TR[dd]SQ[dp]LB[qq:A])',
+      )
+      await page.evaluate(() => window.__sabaki.goToEnd())
+      await setMoveNumbers(page, 'start')
+
+      const shown = await page.evaluate(() => {
+        let titles = [...document.querySelectorAll('.shudan-vertex')].map((v) =>
+          v.getAttribute('title'),
+        )
+        return {
+          triangle: document.querySelectorAll('.shudan-marker_triangle').length,
+          square: document.querySelectorAll('.shudan-marker_square').length,
+          label: titles.includes('A'),
+          moveNumber: titles.includes('1'),
+        }
+      })
+
+      expect(shown.triangle).toBe(1)
+      expect(shown.square).toBe(1)
+      expect(shown.label).toBe(true)
+      expect(shown.moveNumber).toBe(true)
     })
   })
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -64,5 +64,10 @@ module.exports = defineConfig({
       testMatch: /edit-compressed-points\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'comment-coordinate',
+      testMatch: /comment-coordinate\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -357,7 +357,11 @@ export default class Goban extends Component {
     // Draw move numbers
 
     if (showMoveNumbers) {
-      markerMap = markerMap.map((row) => row.map((_) => null))
+      // Copy each row (markerMap aliases board.markers) so the number labels
+      // below can overwrite only their own vertices. Nulling the whole map here
+      // erased all SGF markup (triangles, squares, labels, ...) board-wide
+      // whenever move numbers were on. See #965.
+      markerMap = markerMap.map((row) => [...row])
 
       let variation = false
       let hotspot = false

--- a/src/components/sidebars/CommentBox.js
+++ b/src/components/sidebars/CommentBox.js
@@ -288,6 +288,14 @@ export default class CommentBox extends Component {
       if (treePositionChanged) {
         this.textareaElement.scrollTop = 0
         this.setState({title, comment})
+      } else if (comment !== this.state.comment) {
+        // The comment changed in place on the current node (e.g. ctrl+click
+        // adding a coordinate). Refresh the textarea; otherwise it keeps the
+        // stale value and the next blur commits it back, dropping the change.
+        // Typing can't trigger this: keystrokes reset the commit debounce, so a
+        // commit only lands once the text settles and already matches state.
+        // See #844.
+        this.setState({comment})
       }
 
       return


### PR DESCRIPTION
Two board/comment UI fixes for the v0.60.1 milestone.

**#965 -- move numbers hide all SGF markup.** Turning on move numbers rebuilt the marker map as `markerMap.map(row => row.map(_ => null))`, wiping every triangle, square, circle, cross, and label board-wide and leaving only the numbered move vertices. The wipe was only there to copy the map (it aliases `board.markers`) before overwriting numbered vertices; copying rows with `[...row]` preserves the markup and still lets the numbers overwrite their own vertices. Added a move-numbers e2e asserting a triangle, square, and label coexist with the move number.

**#844 -- ctrl+click coordinate doesn't stick in the comment box.** In edit mode, ctrl+click appends a coordinate to the current node's `C` in place (tree position unchanged), but `CommentBox` only re-synced its textarea on a tree-position change, so the coordinate never showed and the next blur committed the stale text back, dropping it. Now it also syncs `state.comment` when the comment prop changes in place while editing. Keystrokes can't trigger a spurious sync: they reset the commit debounce, so a commit only lands once the text settles and already matches state. Added a `comment-coordinate` e2e.

`npm test` (88) plus the new move-numbers and comment-coordinate e2e are green.

Fixes #965
Fixes #844
