### PR TITLE
Record the game result when resigning (#915)

### DIFF
--- a/e2e/resign.spec.js
+++ b/e2e/resign.spec.js
@@ -1,0 +1,25 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// #915: Play -> Resign recorded a pass but never set the game result, because
+// makeResign built the RE update on a stale tree and never committed it. After
+// a black move (white to play), resigning should record RE = "B+Resign".
+const SGF = '(;GM[1]FF[4]SZ[19];B[pd])'
+
+test.describe('resign (#915)', () => {
+  test('records the game result on the root', async ({page}) => {
+    await loadSgfStringAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+    await page.evaluate(() => window.__sabaki.makeResign())
+    await waitForRender(page)
+
+    const re = await page.evaluate(() => {
+      const s = window.__sabaki
+      const tree = s.state.gameTrees[s.state.gameIndex]
+      return tree.root.data.RE ? tree.root.data.RE[0] : null
+    })
+
+    expect(re).toBe('B+Resign')
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -69,5 +69,10 @@ module.exports = defineConfig({
       testMatch: /comment-coordinate\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'resign',
+      testMatch: /resign\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1323,6 +1323,12 @@ class Sabaki extends EventEmitter {
       draft.updateProperty(draft.root.id, 'RE', [`${color}+Resign`])
     })
 
+    // Commit the result before the pass move, otherwise this RE update was
+    // built on a stale tree and dropped, so Resign only recorded a pass with no
+    // result. makeMainVariation/makeMove read this.state synchronously, so they
+    // now build on the tree that carries RE. See #915.
+    this.setCurrentTreePosition(newTree, treePosition)
+
     this.makeMainVariation(treePosition)
     this.makeMove([-1, -1], {player})
 


### PR DESCRIPTION
Play -> Resign built an `RE` update (`W+Resign` / `B+Resign`) on a fresh tree but never committed it, then called `makeMainVariation` + `makeMove([-1, -1])`. So the only visible effect was a pass move being appended, and the game result was silently dropped -- which is why resigning looked like it just passed (#915).

The fix commits the `RE` tree before the pass. `setState` is synchronous (`Object.assign(this.state, change)`) and `makeMainVariation`/`makeMove` read `this.state` at entry, so they now build on the tree that carries `RE`, matching how the engine-resign path records the result. Added a `resign` e2e that resigns after a black move and asserts `RE` is `B+Resign` on the root (verified it fails without the commit).

Fixes #915
