### PR TITLE
Keep the last-move indicator visible under older themes (#904)

### DIFF
--- a/e2e/last-move-indicator.spec.js
+++ b/e2e/last-move-indicator.spec.js
@@ -1,0 +1,45 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// #904: the last-move indicator is a Shudan `point` marker, rendered as an SVG
+// dot since Shudan 1.7. Older themes (e.g. upsided's Happy Stones / BadukTV)
+// set `background` on it -- a leftover from when it was a <div> -- which painted
+// a solid square over the whole vertex. Sabaki now neutralizes that with an
+// !important rule so the indicator renders regardless of theme.
+const SGF = '(;GM[1]FF[4]SZ[19];B[pd])'
+
+test.describe('last-move indicator (#904)', () => {
+  test('ignores a theme background on the point marker', async ({page}) => {
+    await loadSgfStringAndWait(page, SGF)
+    await page.evaluate(() => window.__sabaki.goToEnd())
+    await waitForRender(page)
+
+    // The last move (pd, a black stone -> sign_1) carries a point marker.
+    const marker = page
+      .locator('.shudan-vertex.shudan-marker_point .shudan-marker')
+      .first()
+    await marker.waitFor({state: 'attached'})
+
+    // Inject a theme-style rule like the ones that broke the indicator; it
+    // loads after Sabaki's stylesheet, exactly as a theme would.
+    await page.evaluate(() => {
+      const s = document.createElement('style')
+      s.textContent =
+        '.shudan-vertex.shudan-marker_point.shudan-sign_1 .shudan-marker { background: rgb(255, 0, 0); }'
+      document.head.appendChild(s)
+    })
+    await waitForRender(page)
+
+    const bg = await page.evaluate(() => {
+      const el = document.querySelector(
+        '.shudan-vertex.shudan-marker_point .shudan-marker',
+      )
+      return getComputedStyle(el).backgroundColor
+    })
+
+    // Sabaki's shim (background: transparent !important) wins over the theme
+    // rule, so no red square is painted over the stone.
+    expect(bg).toBe('rgba(0, 0, 0, 0)')
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -74,5 +74,10 @@ module.exports = defineConfig({
       testMatch: /resign\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'last-move-indicator',
+      testMatch: /last-move-indicator\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/style/index.css
+++ b/style/index.css
@@ -1430,3 +1430,14 @@ header {
 .shudan-vertex .shudan-heat {
   transition: none;
 }
+
+/* The last-move indicator is an SVG dot since Shudan 1.7. Older themes (e.g.
+   upsided's Happy Stones / BadukTV) still set `background` on it -- a leftover
+   from when it was a <div> -- which now paints a solid square over the whole
+   vertex instead of coloring the dot. Neutralize it so the indicator renders
+   correctly regardless of theme; themes should color the dot with `fill`. The
+   theme stylesheet loads after this one, so !important is needed to win. See
+   #904. */
+.shudan-vertex.shudan-marker_point .shudan-marker {
+  background: transparent !important;
+}


### PR DESCRIPTION
The last-move indicator is a Shudan `point` marker, rendered as an SVG dot since Shudan 1.7. Some popular themes (upsided's Happy Stones and BadukTV) still set `background` on it, a leftover from when Shudan rendered the marker as a `<div>`. On the new SVG marker `background` paints a solid square over the whole vertex instead of coloring the dot, so the indicator looks broken (this is the regression from #904; the maintainer's earlier investigation traced it to exactly that theme rule).

Fix: neutralize `background` on point markers in Sabaki's own stylesheet with `!important`. The theme stylesheet loads after Sabaki's, so `!important` is needed to win, and the indicator then renders as Shudan's default dot regardless of theme. Themes that want a custom indicator color should set `fill` (which still works). Added an e2e that injects a theme-style `background` rule on the point marker and asserts it stays transparent (verified it fails without the `!important`).

Fixes #904
