### PR TITLE
Give heatmap win-rate labels a Linux-safe font stack (#804)

### DIFF
--- a/e2e/heatmap-label-font.spec.js
+++ b/e2e/heatmap-label-font.spec.js
@@ -1,0 +1,35 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, waitForRender} = require('./helpers')
+
+// #804: heatmap win-rate labels inherited the app font stack, which leads with
+// 'Segoe UI'. On Linux that's the first font tried, and some font packages
+// (e.g. ttf-vista-fonts) alias it to a face that rendered the tiny labels blank
+// -- so the numbers vanished until users installed a Windows font package.
+// Sabaki now pins the labels to broadly-available fonts with a generic
+// fallback, independent of 'Segoe UI'.
+test.describe('heatmap label font (#804)', () => {
+  test('heat labels use a font stack independent of Segoe UI', async ({
+    page,
+  }) => {
+    await loadSgfStringAndWait(page, '(;GM[1]FF[4]SZ[19];B[pd])')
+    await waitForRender(page)
+
+    const fontFamily = await page.evaluate(() => {
+      // Inject a heat label into a real vertex (as the analysis heatmap would)
+      // and read the font-family the stylesheet resolves for it.
+      const vertex = document.querySelector('.shudan-vertex')
+      const label = document.createElement('div')
+      label.className = 'shudan-heatlabel'
+      label.textContent = '55'
+      vertex.appendChild(label)
+      const ff = getComputedStyle(label).fontFamily
+      label.remove()
+      return ff
+    })
+
+    expect(fontFamily.toLowerCase()).not.toContain('segoe')
+    expect(fontFamily.toLowerCase()).toContain('sans-serif')
+    expect(fontFamily).toContain('Noto Sans')
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -79,5 +79,10 @@ module.exports = defineConfig({
       testMatch: /last-move-indicator\.spec\.js/,
       dependencies: ['smoke'],
     },
+    {
+      name: 'heatmap-label-font',
+      testMatch: /heatmap-label-font\.spec\.js/,
+      dependencies: ['smoke'],
+    },
   ],
 })

--- a/style/index.css
+++ b/style/index.css
@@ -1423,6 +1423,18 @@ header {
 
 /* Override Shudan styles */
 
+/* The heatmap win-rate labels inherit the app font stack, which leads with
+   'Segoe UI'. On Linux that's the first font actually tried, and some font
+   packages (e.g. ttf-vista-fonts) alias it to a face that renders these tiny
+   labels blank -- so the numbers vanished until users installed a Windows font
+   package. Pin the labels to broadly-available fonts (Noto/DejaVu/Liberation
+   ship on virtually every Linux desktop) with a generic fallback, so they never
+   depend on a non-free font. See #804. */
+.shudan-vertex .shudan-heatlabel {
+  font-family: 'Noto Sans', 'DejaVu Sans', 'Liberation Sans', Roboto, Arial,
+    sans-serif;
+}
+
 .shudan-vertex .shudan-heatlabel::first-line {
   font-weight: bold;
 }


### PR DESCRIPTION
The heatmap win-rate labels inherited the app font stack, which leads with `'Segoe UI'`. On Linux that's the first font actually tried, and some font packages (e.g. `ttf-vista-fonts`) alias it to a face that renders these tiny labels blank -- the `sans-serif` fallback never kicks in because a (broken) `'Segoe UI'` *is* found. That's why the percentages showed up only after installing a Windows font package, which is exactly what we don't want to require.

Pin the labels to broadly-available fonts (`Noto Sans` / `DejaVu Sans` / `Liberation Sans` ship on virtually every Linux desktop) with a generic `sans-serif` fallback and no `'Segoe UI'`, so they render regardless of which font packages are installed. Scoped to the heat labels since that's the reported element; the rest of the UI renders fine on the same systems.

Fixes #804
