### PR TITLE
Add a beta Flatpak build for Linux (#803)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,6 +51,22 @@ jobs:
       - name: Build distributables
         if: runner.os != 'macOS'
         run: npm run ${{ matrix.dist }}
+      # Beta Flatpak (Linux only). Best-effort and non-fatal: this is an
+      # unverified beta (see #803), so a failure here must never block the
+      # AppImage / macOS / Windows artifacts. It runs after the AppImage build so
+      # the -beta.flatpak lands alongside it in dist/ for the upload below.
+      - name: Build Flatpak (beta)
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder
+          flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub \
+            org.freedesktop.Platform//23.08 \
+            org.freedesktop.Sdk//23.08 \
+            org.electronjs.Electron2.BaseApp//23.08
+          npm run dist:flatpak
       # No auto-update client ships yet. --glob: Windows runners use
       # PowerShell, which does not expand wildcards.
       - name: Remove auto-update metadata

--- a/package.json
+++ b/package.json
@@ -33,6 +33,21 @@
       "category": "Game",
       "artifactName": "sabaki-v${version}-linux-${arch}.${ext}"
     },
+    "flatpak": {
+      "runtimeVersion": "23.08",
+      "baseVersion": "23.08",
+      "finishArgs": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--socket=pulseaudio",
+        "--share=network",
+        "--filesystem=home",
+        "--talk-name=org.freedesktop.Flatpak"
+      ],
+      "artifactName": "sabaki-v${version}-linux-${arch}-beta.${ext}"
+    },
     "mac": {
       "target": [
         "dmg"
@@ -147,6 +162,7 @@
     "watch": "concurrently \"webpack --mode development --watch\" \"npm run watch-format\"",
     "dist:macos": "npm run bundle && electron-builder -m --x64 --arm64 --publish never",
     "dist:linux": "npm run bundle && electron-builder -l --x64 --arm64 --publish never && node ./ci/normalizeArtifactNames.js",
+    "dist:flatpak": "npm run bundle && electron-builder -l flatpak --x64 --publish never",
     "dist:win64": "npm run bundle && electron-builder -w --x64 --publish never && node ./ci/mv.js ./dist/sabaki-vx.x.x-win.exe ./dist/sabaki-vx.x.x-win-x64-setup.exe",
     "dist:win64-portable": "npm run bundle && electron-builder -w portable --x64 --publish never && node ./ci/mv.js ./dist/sabaki-vx.x.x-win.exe ./dist/sabaki-vx.x.x-win-x64-portable.exe",
     "dist:win": "npm run dist:win64 && npm run dist:win64-portable",

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -48,7 +48,24 @@ export default class EngineSyncer extends EventEmitter {
 
     let absolutePath = resolve(path)
     let executePath = existsSync(absolutePath) ? absolutePath : path
-    this.controller = new Controller(executePath, [...argvsplit(args)], {
+    let executeArgs = [...argvsplit(args)]
+
+    // Inside a Flatpak sandbox (FLATPAK_ID set), user-provided engine binaries
+    // live on the host and can't be executed directly. Route them through
+    // `flatpak-spawn --host`, which needs the org.freedesktop.Flatpak talk-name
+    // permission granted in the Flatpak build. --directory keeps the engine's
+    // working directory (e.g. for weight files referenced relatively). See #803.
+    if (process.env.FLATPAK_ID != null) {
+      executeArgs = [
+        '--host',
+        `--directory=${dirname(absolutePath)}`,
+        executePath,
+        ...executeArgs,
+      ]
+      executePath = 'flatpak-spawn'
+    }
+
+    this.controller = new Controller(executePath, executeArgs, {
       cwd: dirname(absolutePath),
     })
 


### PR DESCRIPTION
Adds a **beta** Flatpak package for Linux (#803).

**Heads up: this is an unverified beta.** It builds in CI but hasn't been tested end-to-end on a real Flatpak install yet, so it goes out looking for testers rather than as a finished artifact.

What's here:

- An electron-builder `flatpak` target with sandbox `finish-args` for the GUI (`x11`/`wayland`/`dri`), sound (`pulseaudio`), `network`, and `--filesystem=home` for reading/writing SGF files, plus `--talk-name=org.freedesktop.Flatpak`.
- Engine spawning through the sandbox: a Flatpak can't execute host binaries directly, so `EngineSyncer` detects `FLATPAK_ID` and routes user-provided engines through `flatpak-spawn --host` (with `--directory` so the engine keeps its working dir, e.g. for relative weight-file paths). Outside a sandbox this path is a no-op -- the `Controller` is constructed exactly as before.
- The Flatpak builds as a **separate, non-fatal** step in `create-release.yml` (`continue-on-error`), so a beta build failure can never block the AppImage / macOS / Windows artifacts. The artifact is named `-beta`.

Known unknowns for testers: whether the runtime version (23.08) and Electron base app resolve cleanly in CI, and whether engine spawning via `flatpak-spawn --host` works with a typical KataGo/Leela setup. Flathub submission is deliberately out of scope here (separate process).

Part of #803.
