### PR TITLE
Fix packaged-app crash: bundle src/modules/utils.js for main.js (#1058)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
       "!**/{.github,.c9,scss,docs,test,tests,devtools,plugins,examples}${/*}",
       "!ci${/*}",
       "!src/{components,modules}${/*}",
+      "src/modules/utils.js",
       "!engines",
       "!node_modules",
       "node_modules/@primer/octicons/build/svg/*",

--- a/test/packagingTests.js
+++ b/test/packagingTests.js
@@ -1,0 +1,33 @@
+import assert from 'assert'
+import {readFileSync} from 'fs'
+import {fileURLToPath} from 'url'
+import {dirname, join} from 'path'
+
+// main.js runs unbundled from the packaged asar, so any src/modules file it
+// requires must be included by build.files -- which otherwise excludes
+// src/modules entirely because the renderer is webpack-bundled. #1044 added a
+// `require('./modules/utils')` without re-including the file, so the packaged
+// v0.60.1 crashed on launch with "Cannot find module './modules/utils'"
+// (#1058). This guards against that recurring; it's exactly the kind of bug the
+// source-based e2e can't see.
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
+const mainSource = readFileSync(join(root, 'src', 'main.js'), 'utf8')
+
+describe('main-process packaging', () => {
+  it('build.files packages every src/modules file main.js requires', () => {
+    const files = pkg.build.files
+    const required = [
+      ...mainSource.matchAll(/require\(\s*['"]\.\/modules\/([\w-]+)['"]\s*\)/g),
+    ].map((m) => m[1])
+
+    for (const mod of required) {
+      const packagedPath = `src/modules/${mod}.js`
+      assert.ok(
+        files.includes(packagedPath),
+        `main.js requires ./modules/${mod}, so build.files must list "${packagedPath}" to re-include it past the src/modules exclusion; otherwise the packaged app crashes with "Cannot find module".`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
The packaged v0.60.1 crashes on launch on every platform with `Cannot find module './modules/utils'`.

**Cause:** #1044 added `require('./modules/utils')` to `main.js` (the main process, which runs unbundled from the asar), but `build.files` excludes `src/modules` entirely, since the renderer is webpack-bundled. So `utils.js` never shipped, and the main process fails to load. The source-based e2e never caught it because it runs from source, not the packaged asar.

**Fix:** re-include just `src/modules/utils.js` past the exclusion (it's a pure, self-contained module). Verified by building the package and launching it: the asar now contains `src/modules/utils.js` and the app starts cleanly. Also added a unit test that asserts `build.files` packages every `./modules/*` file `main.js` requires, so this can't regress silently.

Fixes #1058.