### PR TITLE
v0.60.2: move argv parsing to a main-process module (proper #1058 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Sabaki v0.60.1][v0.60.1] (2026-07-08)
+## [Sabaki v0.60.2][v0.60.2] (2026-07-09)
 
 A bugfix and stability release on top of v0.60.0, plus an experimental Linux
-Flatpak build.
+Flatpak build. (v0.60.1 was withdrawn before promotion: a packaging bug crashed
+the app on launch. v0.60.2 is the same set of fixes with that resolved.)
 
 ### Fixed
 
@@ -1180,7 +1181,7 @@ contributed while things were quiet.
 First release
 
 [unreleased]: https://github.com/SabakiHQ/Sabaki/compare/v0.51.0...master
-[v0.60.1]: https://github.com/SabakiHQ/Sabaki/compare/v0.60.0...v0.60.1
+[v0.60.2]: https://github.com/SabakiHQ/Sabaki/compare/v0.60.0...v0.60.2
 [v0.60.0]: https://github.com/SabakiHQ/Sabaki/compare/v0.52.2...v0.60.0
 [v0.51.0]: https://github.com/SabakiHQ/Sabaki/compare/v0.50.1...v0.51.0
 [v0.50.1]: https://github.com/SabakiHQ/Sabaki/compare/v0.50.0...v0.50.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sabaki",
   "productName": "Sabaki",
-  "version": "0.60.1",
+  "version": "0.60.2",
   "description": "An elegant Go/Baduk/Weiqi board and SGF editor for a more civilized age.",
   "author": "Yichuan Shen <shen.yichuan@gmail.com>",
   "homepage": "http://sabaki.yichuanshen.de",
@@ -91,7 +91,6 @@
       "!**/{.github,.c9,scss,docs,test,tests,devtools,plugins,examples}${/*}",
       "!ci${/*}",
       "!src/{components,modules}${/*}",
-      "src/modules/utils.js",
       "!engines",
       "!node_modules",
       "node_modules/@primer/octicons/build/svg/*",

--- a/src/argv.js
+++ b/src/argv.js
@@ -1,0 +1,18 @@
+// Pure main-process helpers. Lives at the src root, not src/modules: main.js
+// loads it unbundled, and src/modules ships only inside the renderer bundle.
+
+// Returns the file to open from process.argv, or null, skipping flags, the dev
+// "." entry, and the packaged app path.
+exports.getOpenFileFromArgv = function (argv) {
+  let files = argv
+    .slice(1)
+    .filter(
+      (arg) =>
+        !arg.startsWith('-') &&
+        arg !== '.' &&
+        !arg.endsWith('.asar') &&
+        !arg.endsWith('.asar/'),
+    )
+
+  return files.length > 0 ? files[0] : null
+}

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -357,10 +357,8 @@ export default class Goban extends Component {
     // Draw move numbers
 
     if (showMoveNumbers) {
-      // Copy each row (markerMap aliases board.markers) so the number labels
-      // below can overwrite only their own vertices. Nulling the whole map here
-      // erased all SGF markup (triangles, squares, labels, ...) board-wide
-      // whenever move numbers were on. See #965.
+      // Copy each row (markerMap aliases board.markers) so numbers overwrite
+      // only their own vertices without dropping other markup.
       markerMap = markerMap.map((row) => [...row])
 
       let variation = false

--- a/src/components/sidebars/CommentBox.js
+++ b/src/components/sidebars/CommentBox.js
@@ -289,12 +289,8 @@ export default class CommentBox extends Component {
         this.textareaElement.scrollTop = 0
         this.setState({title, comment})
       } else if (comment !== this.state.comment) {
-        // The comment changed in place on the current node (e.g. ctrl+click
-        // adding a coordinate). Refresh the textarea; otherwise it keeps the
-        // stale value and the next blur commits it back, dropping the change.
-        // Typing can't trigger this: keystrokes reset the commit debounce, so a
-        // commit only lands once the text settles and already matches state.
-        // See #844.
+        // An in-place comment change (e.g. ctrl+click adds a coordinate) must
+        // refresh the textarea, or the next blur commits the stale value back.
         this.setState({comment})
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const {resolve} = require('path')
 const i18n = require('./i18n')
 const setting = require('./setting')
 const updater = require('./updater')
-const {getOpenFileFromArgv} = require('./modules/utils')
+const {getOpenFileFromArgv} = require('./argv')
 
 let windows = []
 let openfile = null

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -50,11 +50,8 @@ export default class EngineSyncer extends EventEmitter {
     let executePath = existsSync(absolutePath) ? absolutePath : path
     let executeArgs = [...argvsplit(args)]
 
-    // Inside a Flatpak sandbox (FLATPAK_ID set), user-provided engine binaries
-    // live on the host and can't be executed directly. Route them through
-    // `flatpak-spawn --host`, which needs the org.freedesktop.Flatpak talk-name
-    // permission granted in the Flatpak build. --directory keeps the engine's
-    // working directory (e.g. for weight files referenced relatively). See #803.
+    // In a Flatpak sandbox, host engine binaries can't be run directly; route
+    // them through flatpak-spawn --host, preserving the working directory.
     if (process.env.FLATPAK_ID != null) {
       executeArgs = [
         '--host',
@@ -226,11 +223,8 @@ export default class EngineSyncer extends EventEmitter {
       try {
         await this.controller.sendCommand({name: 'protocol_version'})
       } catch (err) {
-        // Best-effort interrupt: if the engine has already stopped (e.g. it's
-        // being killed during shutdown) the command rejects with "GTP engine
-        // output has stopped". queueCommand()/sync() fire this without awaiting,
-        // so swallow it here rather than surface an unhandled rejection. See
-        // #720.
+        // Best-effort interrupt: callers don't await this, so swallow the
+        // rejection when the engine has already stopped.
       }
     }
   }

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1304,9 +1304,8 @@ class Sabaki extends EventEmitter {
   }
 
   makePass() {
-    // A pass is a play action, so mirror board-click behavior and let an
-    // attached engine respond to it -- unless an engine-vs-engine game is
-    // already driving the moves. See #857.
+    // Let an attached engine respond to the pass, as it does for a board click,
+    // unless an engine-vs-engine game is already driving moves.
     this.makeMove([-1, -1], {
       generateEngineMove: this.state.engineGameOngoing == null,
     })
@@ -1323,10 +1322,8 @@ class Sabaki extends EventEmitter {
       draft.updateProperty(draft.root.id, 'RE', [`${color}+Resign`])
     })
 
-    // Commit the result before the pass move, otherwise this RE update was
-    // built on a stale tree and dropped, so Resign only recorded a pass with no
-    // result. makeMainVariation/makeMove read this.state synchronously, so they
-    // now build on the tree that carries RE. See #915.
+    // Commit the result first so the pass below builds on the tree carrying RE
+    // (setState is synchronous).
     this.setCurrentTreePosition(newTree, treePosition)
 
     this.makeMainVariation(treePosition)

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -132,26 +132,8 @@ export function cycleAreaValue(value, steps) {
 // `argv[0]` is the binary; everything that isn't a file to open is filtered out:
 // flags (any leading '-', so Chromium's '--no-sandbox' and macOS's '-psn_...'
 // both go), the dev-mode entry '.', and the packaged-app entry ('*.asar'). Some
-// Linux launchers (snap, AppImage '.desktop' files) inject flags and ship a
-// renamed binary, so a binary-name or argv-position heuristic isn't reliable --
-// filter by content instead. Returns the first surviving argument. See #954.
-export function getOpenFileFromArgv(argv) {
-  let files = argv
-    .slice(1)
-    .filter(
-      (arg) =>
-        !arg.startsWith('-') &&
-        arg !== '.' &&
-        !arg.endsWith('.asar') &&
-        !arg.endsWith('.asar/'),
-    )
-
-  return files.length > 0 ? files[0] : null
-}
-
-// Maps each Clean Markup category to the SGF properties it strips. `label`
-// covers both modern LB[] labels and old-style L[] labels (FF[3]), which Sabaki
-// still reads and renders (see gametree.js), so cleaning labels must remove both.
+// Clean Markup category -> SGF properties. `label` covers both LB[] and
+// old-style L[], both of which Sabaki renders.
 export const markupCleanupProperties = {
   cross: ['MA'],
   triangle: ['TR'],

--- a/style/index.css
+++ b/style/index.css
@@ -1423,13 +1423,9 @@ header {
 
 /* Override Shudan styles */
 
-/* The heatmap win-rate labels inherit the app font stack, which leads with
-   'Segoe UI'. On Linux that's the first font actually tried, and some font
-   packages (e.g. ttf-vista-fonts) alias it to a face that renders these tiny
-   labels blank -- so the numbers vanished until users installed a Windows font
-   package. Pin the labels to broadly-available fonts (Noto/DejaVu/Liberation
-   ship on virtually every Linux desktop) with a generic fallback, so they never
-   depend on a non-free font. See #804. */
+/* Don't inherit the app font stack (leads with 'Segoe UI', which is missing or
+   broken on some Linux setups and left these tiny labels blank); pin to widely
+   available fonts. */
 .shudan-vertex .shudan-heatlabel {
   font-family: 'Noto Sans', 'DejaVu Sans', 'Liberation Sans', Roboto, Arial,
     sans-serif;
@@ -1443,13 +1439,9 @@ header {
   transition: none;
 }
 
-/* The last-move indicator is an SVG dot since Shudan 1.7. Older themes (e.g.
-   upsided's Happy Stones / BadukTV) still set `background` on it -- a leftover
-   from when it was a <div> -- which now paints a solid square over the whole
-   vertex instead of coloring the dot. Neutralize it so the indicator renders
-   correctly regardless of theme; themes should color the dot with `fill`. The
-   theme stylesheet loads after this one, so !important is needed to win. See
-   #904. */
+/* Some themes set `background` on the last-move dot (a leftover from when it was
+   a <div>); on the current SVG marker that paints a square over the vertex.
+   Neutralize it -- theme stylesheets load after this one, so !important wins. */
 .shudan-vertex.shudan-marker_point .shudan-marker {
   background: transparent !important;
 }

--- a/test/argvTests.js
+++ b/test/argvTests.js
@@ -1,0 +1,62 @@
+import assert from 'assert'
+
+import {getOpenFileFromArgv} from '../src/argv.js'
+
+// Backs the launch-time "open this file" handling in main.js. argv[0] is always
+// the binary; the file to open (if any) is somewhere in the rest, mixed with
+// flags and the app entry point. See issue #954.
+describe('getOpenFileFromArgv', () => {
+  const dev = '/opt/electron' // dev: `electron . [flags] [file]`
+  const devRenamed = '/usr/bin/electron42' // some Linux distros rename it
+  const macApp = '/Applications/Sabaki.app/Contents/MacOS/Sabaki'
+  const winExe = 'C:\\Program Files\\Sabaki\\Sabaki.exe'
+  const linuxBin = '/opt/Sabaki/sabaki'
+  const file = '/home/u/game.sgf'
+
+  it('returns null when only the binary is present', () => {
+    assert.strictEqual(getOpenFileFromArgv([macApp]), null)
+    assert.strictEqual(getOpenFileFromArgv([]), null)
+  })
+
+  it('reads a file passed to a packaged app', () => {
+    assert.strictEqual(getOpenFileFromArgv([winExe, file]), file)
+    assert.strictEqual(getOpenFileFromArgv([macApp, file]), file)
+    assert.strictEqual(getOpenFileFromArgv([linuxBin, file]), file)
+  })
+
+  it('skips the dev-mode "." entry', () => {
+    assert.strictEqual(getOpenFileFromArgv([dev, '.']), null)
+    assert.strictEqual(getOpenFileFromArgv([dev, '.', file]), file)
+  })
+
+  it('works regardless of the binary name (renamed Linux electron)', () => {
+    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.', file]), file)
+    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.']), null)
+  })
+
+  it('ignores injected flags (snap/AppImage --no-sandbox, #954)', () => {
+    assert.strictEqual(getOpenFileFromArgv([linuxBin, '--no-sandbox']), null)
+    assert.strictEqual(
+      getOpenFileFromArgv([linuxBin, '--no-sandbox', file]),
+      file,
+    )
+    assert.strictEqual(getOpenFileFromArgv([dev, '.', '--inspect', file]), file)
+    assert.strictEqual(
+      getOpenFileFromArgv([winExe, '--disable-gpu', file]),
+      file,
+    )
+  })
+
+  it('ignores single-dash args (e.g. macOS -psn_)', () => {
+    assert.strictEqual(getOpenFileFromArgv([macApp, '-psn_0_12345']), null)
+    assert.strictEqual(
+      getOpenFileFromArgv([macApp, '-psn_0_12345', file]),
+      file,
+    )
+  })
+
+  it('skips the packaged .asar entry', () => {
+    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar', file]), file)
+    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar/']), null)
+  })
+})

--- a/test/packagingTests.js
+++ b/test/packagingTests.js
@@ -3,31 +3,32 @@ import {readFileSync} from 'fs'
 import {fileURLToPath} from 'url'
 import {dirname, join} from 'path'
 
-// main.js runs unbundled from the packaged asar, so any src/modules file it
-// requires must be included by build.files -- which otherwise excludes
-// src/modules entirely because the renderer is webpack-bundled. #1044 added a
-// `require('./modules/utils')` without re-including the file, so the packaged
-// v0.60.1 crashed on launch with "Cannot find module './modules/utils'"
-// (#1058). This guards against that recurring; it's exactly the kind of bug the
-// source-based e2e can't see.
+// main.js runs unbundled from the packaged asar, so it must not require from
+// src/modules or src/components -- those are renderer code, compiled into
+// bundle.js and dropped from the package by the build.files filter. #1044 broke
+// this by requiring src/modules/utils from main.js, so the packaged v0.60.1
+// crashed on launch with "Cannot find module './modules/utils'" (#1058). The
+// source-based e2e can't catch it (it runs from source, not the asar). Pure
+// main-process logic belongs at the src root (e.g. src/argv.js) instead. See the
+// "Process boundaries" note in CLAUDE.md.
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
-const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'))
 const mainSource = readFileSync(join(root, 'src', 'main.js'), 'utf8')
 
-describe('main-process packaging', () => {
-  it('build.files packages every src/modules file main.js requires', () => {
-    const files = pkg.build.files
-    const required = [
-      ...mainSource.matchAll(/require\(\s*['"]\.\/modules\/([\w-]+)['"]\s*\)/g),
-    ].map((m) => m[1])
+describe('main-process module boundary', () => {
+  it('main.js does not require renderer modules (src/modules, src/components)', () => {
+    const crossings = [
+      ...mainSource.matchAll(
+        /require\(\s*['"]\.\/(modules|components)\/([\w-]+)['"]\s*\)/g,
+      ),
+    ].map((m) => `./${m[1]}/${m[2]}`)
 
-    for (const mod of required) {
-      const packagedPath = `src/modules/${mod}.js`
-      assert.ok(
-        files.includes(packagedPath),
-        `main.js requires ./modules/${mod}, so build.files must list "${packagedPath}" to re-include it past the src/modules exclusion; otherwise the packaged app crashes with "Cannot find module".`,
-      )
-    }
+    assert.deepStrictEqual(
+      crossings,
+      [],
+      `main.js runs unbundled from the asar but requires renderer module(s): ${crossings.join(
+        ', ',
+      )}. build.files excludes src/modules and src/components, so the packaged app would crash with "Cannot find module". Move that logic to a src-root main-process module (see src/argv.js).`,
+    )
   })
 })

--- a/test/utilsTests.js
+++ b/test/utilsTests.js
@@ -1,10 +1,6 @@
 import assert from 'assert'
 
-import {
-  cycleAreaValue,
-  getOpenFileFromArgv,
-  markupCleanupProperties,
-} from '../src/modules/utils.js'
+import {cycleAreaValue, markupCleanupProperties} from '../src/modules/utils.js'
 
 // cycleAreaValue backs the manual territory overrides in scoring/estimator mode.
 // Area values are -1 (white) / 0 (neutral) / 1 (black), and `steps` advances a
@@ -27,65 +23,6 @@ describe('cycleAreaValue', () => {
       assert.strictEqual(cycleAreaValue(base, 3), base)
       assert.strictEqual(cycleAreaValue(base, 6), base)
     }
-  })
-})
-
-// Backs the launch-time "open this file" handling in main.js. argv[0] is always
-// the binary; the file to open (if any) is somewhere in the rest, mixed with
-// flags and the app entry point. See issue #954.
-describe('getOpenFileFromArgv', () => {
-  const dev = '/opt/electron' // dev: `electron . [flags] [file]`
-  const devRenamed = '/usr/bin/electron42' // some Linux distros rename it
-  const macApp = '/Applications/Sabaki.app/Contents/MacOS/Sabaki'
-  const winExe = 'C:\\Program Files\\Sabaki\\Sabaki.exe'
-  const linuxBin = '/opt/Sabaki/sabaki'
-  const file = '/home/u/game.sgf'
-
-  it('returns null when only the binary is present', () => {
-    assert.strictEqual(getOpenFileFromArgv([macApp]), null)
-    assert.strictEqual(getOpenFileFromArgv([]), null)
-  })
-
-  it('reads a file passed to a packaged app', () => {
-    assert.strictEqual(getOpenFileFromArgv([winExe, file]), file)
-    assert.strictEqual(getOpenFileFromArgv([macApp, file]), file)
-    assert.strictEqual(getOpenFileFromArgv([linuxBin, file]), file)
-  })
-
-  it('skips the dev-mode "." entry', () => {
-    assert.strictEqual(getOpenFileFromArgv([dev, '.']), null)
-    assert.strictEqual(getOpenFileFromArgv([dev, '.', file]), file)
-  })
-
-  it('works regardless of the binary name (renamed Linux electron)', () => {
-    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.', file]), file)
-    assert.strictEqual(getOpenFileFromArgv([devRenamed, '.']), null)
-  })
-
-  it('ignores injected flags (snap/AppImage --no-sandbox, #954)', () => {
-    assert.strictEqual(getOpenFileFromArgv([linuxBin, '--no-sandbox']), null)
-    assert.strictEqual(
-      getOpenFileFromArgv([linuxBin, '--no-sandbox', file]),
-      file,
-    )
-    assert.strictEqual(getOpenFileFromArgv([dev, '.', '--inspect', file]), file)
-    assert.strictEqual(
-      getOpenFileFromArgv([winExe, '--disable-gpu', file]),
-      file,
-    )
-  })
-
-  it('ignores single-dash args (e.g. macOS -psn_)', () => {
-    assert.strictEqual(getOpenFileFromArgv([macApp, '-psn_0_12345']), null)
-    assert.strictEqual(
-      getOpenFileFromArgv([macApp, '-psn_0_12345', file]),
-      file,
-    )
-  })
-
-  it('skips the packaged .asar entry', () => {
-    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar', file]), file)
-    assert.strictEqual(getOpenFileFromArgv([dev, '/app/app.asar/']), null)
   })
 })
 


### PR DESCRIPTION
The proper fix for the v0.60.1 packaging crash (#1058), cut as v0.60.2.

v0.60.1's main process required `./modules/utils`, which the bundler excludes from the package, so it crashed on launch. The quick fix in #1059 re-included that one file; this replaces it with the cleaner structure: `getOpenFileFromArgv` moves to a new `src/argv.js` (a main-process module at the `src` root, which packages by default), `main.js` requires that, and the `src/modules` re-include is reverted so that directory stays renderer-only.

Guards so this can't recur: `test/packagingTests.js` asserts `main.js` never requires from `src/modules`/`src/components`, and `/sabaki-release` now builds and launches the packaged app before tagging (the source e2e runs from source, not the asar, so it couldn't catch this). Verified by building and launching the packaged macOS app.

v0.60.1 is being withdrawn since it never ran; this bumps to v0.60.2 with the same set of fixes plus this one.
