### PR TITLE
add hotkey for show engines sidebar

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -485,6 +485,7 @@ exports.get = function (props = {}) {
           label: i18n.t('menu.engines', 'Show &Engines Sidebar'),
           type: 'checkbox',
           checked: !!showLeftSidebar,
+          accelerator: 'CmdOrCtrl+Shift+B',
           click: () => {
             toggleSetting('view.show_leftsidebar')
             sabaki.setState(({showLeftSidebar}) => ({


### PR DESCRIPTION
Hotkey is `CmdOrCtrl+Shift+B`. B is for "Bar". Chose `CmdOrCtrl+Shift` as the modifier for similarity with existing sidebar toggles like `CmdOrCtrl+Shift+G` and `CmdOrCtrl+Shift+T`. `CmdOrCtrl+Shift+E` is already taken by "Estimate".

Alternatives considered:
- `CmdOrCtrl+Alt+E` - would keep E for "Engine"
- `F6` - would match other Engine hotkeys using function keys