### PR TITLE
Include variation count into theme manifest

### DIFF
--- a/docs/guides/create-themes.md
+++ b/docs/guides/create-themes.md
@@ -24,6 +24,8 @@ will only use the following fields:
 - `author` _(optional)_
 - `homepage` _(optional)_
 - `main` - The CSS file to include in Sabaki, usually `styles.css`
+- `stoneVariations` _(optional)_ - Positive integer variation counts for black
+  and white stones; each color defaults to five
 
 For example:
 
@@ -31,9 +33,17 @@ For example:
 {
   "name": "my-theme",
   "version": "0.1.0",
-  "main": "styles.css"
+  "main": "styles.css",
+  "stoneVariations": {
+    "black": 12,
+    "white": 7
+  }
 }
 ```
+
+The counts may differ. Sabaki assigns `.shudan-random_0` through
+`.shudan-random_{count - 1}` to the corresponding `.shudan-sign_1` (black) or
+`.shudan-sign_-1` (white) stones. Missing or invalid counts default to five.
 
 ## Packing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@sabaki/immutable-gametree": "^1.9.4",
         "@sabaki/influence": "^1.2.2",
         "@sabaki/sgf": "^3.5.0",
-        "@sabaki/shudan": "^1.7.1",
+        "@sabaki/shudan": "^1.8.0",
         "argv-split": "^3.2.1",
         "classnames": "^2.2.6",
         "dolm": "^0.7.3-beta",
@@ -1335,9 +1335,9 @@
       }
     },
     "node_modules/@sabaki/shudan": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@sabaki/shudan/-/shudan-1.7.1.tgz",
-      "integrity": "sha512-wny2PbKAt2gET+6m/Ov5Q/0Xyjbz+UoV/z/eVMsq0rKVxH63/Gm5LDcxVkahbAdAZxKTsvxIjEPnIOSrDUmzNg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sabaki/shudan/-/shudan-1.8.0.tgz",
+      "integrity": "sha512-FeyfSnGgOsxpoB6wujYJwJL4IBT4p/hiA8y/XVhZuxV5z/UxekGpYvuyHzw1V1brMLxUSuJsFrCUg+2TLGEt7Q==",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",
     "@sabaki/sgf": "^3.5.0",
-    "@sabaki/shudan": "^1.7.1",
+    "@sabaki/shudan": "^1.8.0",
     "argv-split": "^3.2.1",
     "classnames": "^2.2.6",
     "dolm": "^0.7.3-beta",

--- a/src/components/Goban.js
+++ b/src/components/Goban.js
@@ -10,7 +10,10 @@ import * as gobantransformer from '../modules/gobantransformer.js'
 import * as helper from '../modules/helper.js'
 
 const t = i18n.context('Goban')
-const setting = {get: (key) => window.sabaki.setting.get(key)}
+const setting = {
+  get: (key) => window.sabaki.setting.get(key),
+  getThemes: () => window.sabaki.setting.getThemes(),
+}
 const alpha = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
 
 export default class Goban extends Component {
@@ -236,6 +239,7 @@ export default class Goban extends Component {
 
       drawLineMode = null,
       transformation = '',
+      currentThemeId,
     },
     {
       top = 0,
@@ -251,6 +255,13 @@ export default class Goban extends Component {
       variationIndex = -1,
     },
   ) {
+    let currentTheme = setting.getThemes()[currentThemeId]
+    let stoneVariations = currentTheme?.stoneVariations
+    let stoneVariationCounts = {
+      1: stoneVariations?.black,
+      [-1]: stoneVariations?.white,
+    }
+
     let signMap = board.signMap
     let markerMap = board.markers
 
@@ -475,6 +486,7 @@ export default class Goban extends Component {
       coordY,
       fuzzyStonePlacement,
       animateStonePlacement: clicked && animateStonePlacement,
+      stoneVariationCounts,
 
       signMap: gobantransformer.transformMap(signMap, transformation),
       markerMap: gobantransformer.transformMap(markerMap, transformation),

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -102,6 +102,7 @@ export default class MainView extends Component {
       fuzzyStonePlacement,
       animateStonePlacement,
       boardTransformation,
+      currentThemeId,
 
       selectedTool,
       findText,
@@ -161,6 +162,7 @@ export default class MainView extends Component {
           showSiblings: mode !== 'guess' && showSiblings,
           fuzzyStonePlacement,
           animateStonePlacement,
+          currentThemeId,
 
           playVariation,
           drawLineMode:

--- a/src/components/ThemeManager.js
+++ b/src/components/ThemeManager.js
@@ -174,9 +174,7 @@ export default class ThemeManager extends Component {
                 }`,
 
         backgroundPath != null &&
-          // Match theme selectors such as `#main main` so the user-selected
-          // background wins by source order instead of losing on specificity.
-          `#main main {
+          `main {
                     background-image: url('${backgroundPath.replace(
                       /\\/g,
                       '/',

--- a/src/components/ThemeManager.js
+++ b/src/components/ThemeManager.js
@@ -174,7 +174,9 @@ export default class ThemeManager extends Component {
                 }`,
 
         backgroundPath != null &&
-          `main {
+          // Match theme selectors such as `#main main` so the user-selected
+          // background wins by source order instead of losing on specificity.
+          `#main main {
                     background-image: url('${backgroundPath.replace(
                       /\\/g,
                       '/',

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -314,6 +314,7 @@ class Sabaki extends EventEmitter {
       'board.analysis_type': 'analysisType',
       'board.analysis_value_type': 'analysisValueType',
       'board.show_analysis': 'showAnalysis',
+      'theme.current': 'currentThemeId',
       'view.show_menubar': 'showMenuBar',
       'view.show_coordinates': 'showCoordinates',
       'view.show_move_colorization': 'showMoveColorization',


### PR DESCRIPTION
This gives users and theme authors more control over board presentation.

Here is a motivation for the changes - a theme with many variations per color and boards that include grid into the image.
<img width="875" height="878" alt="image" src="https://github.com/user-attachments/assets/d73fd1b5-efd0-45bc-a860-cbe7591c9a5e" />

Themes can now declare different numbers of black and white stone variations through `stoneVariations` in `package.json`. Sabaki translates the manifest’s color names into Shudan’s numeric signs and passes the counts to the renderer. Validation and the default count remain in Shudan so the renderer has one authoritative policy and remains safe for non-Sabaki consumers.

Theme selection is also propagated through application state, ensuring variation counts update immediately when switching themes.

Another change is that custom background images selected in Sabaki’s settings now can override the background included in theme. The css rule now has higher specificity. I can extract that into another PR if you prefer.

Requires the accompanying https://github.com/SabakiHQ/Shudan/pull/31