### PR TITLE
Fix Markdown links crashing the comment box (#1069)

### DIFF
--- a/e2e/comment-markdown-link.spec.js
+++ b/e2e/comment-markdown-link.spec.js
@@ -1,0 +1,64 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfStringAndWait, gotoChildPath} = require('./helpers')
+
+// #1069: a Markdown link in a node comment ([text](url)) crashed the comment
+// sidebar. The custom react-markdown renderers in MarkdownContentDisplay were
+// written for react-markdown v8; the v0.60 bump to v10 changed the
+// component/children contract, so Link wrapped its <a> in a ContentDisplay with
+// no `tag`. ContentDisplay then rendered h(undefined, ...) -- the link surfaced
+// as the literal text "[object Object]" and its ref-based querySelectorAll
+// threw, wedging the comment box for the rest of the session.
+//
+// The "]" that closes the link's "[text]" is SGF-escaped (\\]) so it stays
+// inside the C[...] value instead of terminating the property early.
+const SGF =
+  '(;GM[1]FF[4]CA[UTF-8]SZ[19]' +
+  ';B[pd]C[see [the link\\](http://example.com) here]' +
+  ';W[dp]C[second node comment])'
+
+test.describe('Markdown link in a comment (#1069)', () => {
+  test('renders the link without crashing the comment box', async ({page}) => {
+    const pageErrors = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+
+    await loadSgfStringAndWait(page, SGF)
+    // Play (read-only) mode renders the comment as Markdown via
+    // MarkdownContentDisplay; the sidebar only refreshes while it's visible.
+    await page.evaluate(() =>
+      window.__sabaki.setState({showSidebar: true, showCommentBox: true}),
+    )
+
+    // The node whose comment holds the Markdown link.
+    await gotoChildPath(page, [0])
+
+    const comment = page.locator('#properties .comment')
+    await comment.waitFor({state: 'attached'})
+
+    // The link renders as a real external anchor, not the text "[object Object]".
+    const link = comment.locator('a.comment-external')
+    await expect(link).toHaveAttribute('href', 'http://example.com')
+    await expect(link).toHaveText('the link')
+    expect(await comment.innerText()).not.toContain('object Object')
+
+    // The comment box keeps updating on further navigation (no wedge/freeze).
+    await gotoChildPath(page, [0, 0])
+    await expect(comment).toContainText('second node comment')
+
+    // No render-time exception from the comment renderers.
+    expect(pageErrors.join('\n')).not.toContain('querySelectorAll')
+  })
+
+  // The same v8->v10 mismatch left Heading reading a `level` prop that v10 no
+  // longer passes, so every Markdown heading rendered as <hundefined>.
+  test('renders a Markdown heading with the right tag', async ({page}) => {
+    await loadSgfStringAndWait(page, '(;GM[1]FF[4]SZ[19];B[pd]C[## Section])')
+    await page.evaluate(() =>
+      window.__sabaki.setState({showSidebar: true, showCommentBox: true}),
+    )
+    await gotoChildPath(page, [0])
+
+    const heading = page.locator('#properties .comment h2')
+    await expect(heading).toHaveText('Section')
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -70,6 +70,11 @@ module.exports = defineConfig({
       dependencies: ['smoke'],
     },
     {
+      name: 'comment-markdown-link',
+      testMatch: /comment-markdown-link\.spec\.js/,
+      dependencies: ['smoke'],
+    },
+    {
       name: 'resign',
       testMatch: /resign\.spec\.js/,
       dependencies: ['smoke'],

--- a/src/components/ContentDisplay.js
+++ b/src/components/ContentDisplay.js
@@ -164,7 +164,7 @@ export default class ContentDisplay extends Component {
     }
   }
 
-  render({tag, content, children}) {
+  render({tag = 'span', content, children}) {
     return content != null
       ? h(tag, {
           ref: (el) => (this.element = el),
@@ -183,12 +183,13 @@ export default class ContentDisplay extends Component {
         })
       : h(
           tag,
-          Object.assign(
-            {
-              ref: (el) => (this.element = el),
-            },
-            this.props,
-          ),
+          {
+            ref: (el) => (this.element = el),
+            ...this.props,
+            tag: undefined,
+            content: undefined,
+            children: undefined,
+          },
           children,
         )
   }

--- a/src/components/MarkdownContentDisplay.js
+++ b/src/components/MarkdownContentDisplay.js
@@ -57,12 +57,8 @@ function Image({src, alt}) {
   return h(Link, {href: src}, typographer(alt))
 }
 
-function Heading({level, children}) {
-  return h(`h${level}`, {}, typographer(children))
-}
-
-function Html({isBlock, value}) {
-  return h(isBlock ? Paragraph : 'span', {}, value)
+function Heading({node, children}) {
+  return h(node.tagName, {}, typographer(children))
 }
 
 class MarkdownContentDisplay extends Component {
@@ -86,7 +82,6 @@ class MarkdownContentDisplay extends Component {
         h5: Heading,
         h6: Heading,
         code: Paragraph,
-        html: Html,
       },
     })
   }


### PR DESCRIPTION
Addresses #1069.

A Markdown link in a node comment (`[text](http://example.com)`) rendered as the literal text "[object Object]" and then wedged the comment sidebar, so it stopped updating as you navigated between nodes (the "freeze" in the report).

## Root cause

v0.60 bumped react-markdown from 8 to 10, which changed the component/children contract. The custom renderers in `MarkdownContentDisplay` were still written against the v8 API:

- `Link` wraps its `<a>` in a `ContentDisplay` with no `tag`, so `ContentDisplay`'s children branch rendered `h(undefined, ...)`. That surfaced the link as the string "[object Object]", and its ref-based `querySelectorAll` in `componentDidUpdate` threw on a non-DOM ref, which is what wedged the box.
- `Heading` read a `level` prop that v10 no longer passes, so every heading rendered as an invalid `<hundefined>` tag.
- `Html` used the old `{isBlock, value}` shape and there is no `html` component key in v10, so it was dead code.

## Fix

- `ContentDisplay` defaults `tag` to `'span'` and strips its internal props (`tag`/`content`/`children`) in the children branch, matching what the content branch already did. This is the actual crash fix and keeps the external-link click wiring intact.
- `Heading` reads `node.tagName`.
- Remove the dead `Html` renderer and its `html` mapping.

## Tests

New `e2e/comment-markdown-link.spec.js` (project `comment-markdown-link`): a comment with a Markdown link renders as a real external anchor with no wedge on further navigation, and a Markdown heading renders with the correct tag. Both assertions fail on `master` and pass here.

`npm test` (89 passing), `npm run format-check`, and the `smoke` / `comment-coordinate` / `renderer` e2e suites are all green locally.

Left as a non-closing reference since the original report is on a file with Chinese text, so it's worth confirming there isn't a separate encoding issue once the reporter shares the .sgf.
