### PR TITLE
Default the Open dialog to the current file's folder (#1061)

### DIFF
--- a/e2e/open-dialog-default-path.spec.js
+++ b/e2e/open-dialog-default-path.spec.js
@@ -1,0 +1,69 @@
+const {expect} = require('@playwright/test')
+const {test} = require('./fixtures/electron-app')
+const {loadSgfAndWait} = require('./helpers')
+const path = require('path')
+
+// #1061: opening a second file should default the Open dialog to the folder of
+// the file you currently have open. Neither the old nor the new dialog code
+// ever set defaultPath -- the previous "remembers the last folder" behavior was
+// the native dialog's own memory, which the Electron upgrade in v0.60 stopped
+// providing (falling back to Downloads on Windows). loadFile now passes
+// defaultPath explicitly, derived from representedFilename.
+//
+// These tests assert what Sabaki hands the native dialog (the defaultPath in
+// the options), not OS-level folder memory, so they're deterministic across
+// platforms.
+
+const sgfPath = path.resolve(
+  __dirname,
+  '..',
+  'test',
+  'sgf',
+  'beginner_game.sgf',
+)
+
+// Replace the open dialog with a capturing stub that cancels, and clear any
+// previously captured options.
+async function captureOpenDialog(electronApp) {
+  await electronApp.evaluate(({dialog}) => {
+    globalThis.__openDialogOpts = null
+    dialog.showOpenDialog = async (win, opts) => {
+      globalThis.__openDialogOpts = opts
+      return {canceled: true, filePaths: []}
+    }
+  })
+}
+
+async function triggerOpenDialog(page, electronApp) {
+  await page.evaluate(() =>
+    window.__sabaki.loadFile(null, {suppressAskForSave: true}),
+  )
+  return electronApp.evaluate(() => globalThis.__openDialogOpts)
+}
+
+test.describe('Open dialog default folder (#1061)', () => {
+  test('defaults to the folder of the currently open file', async ({
+    page,
+    electronApp,
+  }) => {
+    await loadSgfAndWait(page, sgfPath)
+    await captureOpenDialog(electronApp)
+
+    const opts = await triggerOpenDialog(page, electronApp)
+
+    expect(opts).toBeTruthy()
+    expect(opts.defaultPath).toBe(path.dirname(sgfPath))
+  })
+
+  test('passes no defaultPath when no file is open', async ({
+    page,
+    electronApp,
+  }) => {
+    await captureOpenDialog(electronApp)
+
+    const opts = await triggerOpenDialog(page, electronApp)
+
+    expect(opts).toBeTruthy()
+    expect(opts.defaultPath).toBeUndefined()
+  })
+})

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -70,6 +70,11 @@ module.exports = defineConfig({
       dependencies: ['smoke'],
     },
     {
+      name: 'open-dialog-default-path',
+      testMatch: /open-dialog-default-path\.spec\.js/,
+      dependencies: ['smoke'],
+    },
+    {
       name: 'resign',
       testMatch: /resign\.spec\.js/,
       dependencies: ['smoke'],

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import EventEmitter from 'events'
-import {basename, extname} from 'path'
+import {basename, dirname, extname} from 'path'
 import {ipcRenderer} from 'electron'
 import {h} from 'preact'
 import {v4 as uuid} from 'uuid'
@@ -588,8 +588,13 @@ class Sabaki extends EventEmitter {
     let t = i18n.context('sabaki.file')
 
     if (!filename) {
+      let {representedFilename} = this.state
+
       let result = await dialog.showOpenDialog({
         properties: ['openFile'],
+        defaultPath: representedFilename
+          ? dirname(representedFilename)
+          : undefined,
         filters: [
           ...fileformats.meta,
           {name: t('All Files'), extensions: ['*']},


### PR DESCRIPTION
Addresses #1061.

Opening a second file used to start the Open dialog in the folder of the file you already had open; after the v0.60 upgrade it started defaulting to Downloads on Windows instead.

## Cause

`loadFile`'s `showOpenDialog` never set `defaultPath`, so the initial folder was whatever the native dialog chose. On older Electron that was the last-used directory; the large Electron jump in v0.60 (13 -> 43) dropped that behavior on Windows, so it fell back to the shell default (Downloads). Nothing in Sabaki tracked or set the directory; it relied on the native dialog's own memory.

## Fix

Set `defaultPath` explicitly to `dirname(representedFilename)` (undefined when nothing is open). `representedFilename` is already tracked for the window title / save / reload, so this adds no new state, and it makes the initial folder deterministic on every platform instead of depending on native dialog memory.

## Tests

New `e2e/open-dialog-default-path.spec.js` (project `open-dialog-default-path`) asserts the options Sabaki hands the dialog: with a file open, `defaultPath` is that file's directory (fails on `master`, where it's undefined); with no file open, no `defaultPath` is passed. `npm test`, `npm run format-check`, and the `renderer` e2e suite are green locally.

Left as a non-closing reference since the report is Windows-specific and I can't verify the native dialog there directly, so it's worth a confirmation from the reporter once it ships.
