### PR TITLE
Bump prettier, webpack-cli, @primer/octicons, @sabaki/gtp, preact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "sabaki",
-  "version": "0.60.0",
+  "version": "0.60.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sabaki",
-      "version": "0.60.0",
+      "version": "0.60.2",
       "license": "MIT",
       "dependencies": {
         "@mariotacke/color-thief": "^3.0.1",
-        "@primer/octicons": "^19.29.1",
+        "@primer/octicons": "^19.29.2",
         "@sabaki/boardmatcher": "^1.2.0",
         "@sabaki/deadstones": "^2.2.0",
         "@sabaki/go-board": "^1.4.1",
-        "@sabaki/gtp": "^3.1.0",
+        "@sabaki/gtp": "^3.1.1",
         "@sabaki/i18n": "0.51.1-1",
         "@sabaki/immutable-gametree": "^1.9.4",
         "@sabaki/influence": "^1.2.2",
@@ -28,7 +28,7 @@
         "jschardet": "^3.0.0",
         "natsort": "^2.0.2",
         "pikaday": "^1.8.0",
-        "preact": "^10.4.0",
+        "preact": "^10.29.7",
         "react-markdown": "^10.1.0",
         "remark-breaks": "^4.0.0",
         "rimraf": "^6.1.2",
@@ -42,11 +42,11 @@
         "electron-builder": "^26.8.1",
         "mocha": "^11.7.6",
         "onchange": "^7.1.0",
-        "prettier": "3.8.1",
+        "prettier": "3.9.5",
         "tmp": "^0.2.7",
         "tsx": "^4.23.0",
         "webpack": "^5.108.4",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^7.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -219,9 +219,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1248,9 +1248,9 @@
       }
     },
     "node_modules/@primer/octicons": {
-      "version": "19.29.1",
-      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.29.1.tgz",
-      "integrity": "sha512-XVRArUP8bN+IEjfNQSquXAJinVqAWRx36sVvhN5VzC+gOLfbx16EfFFvcFhSVaqQJ+57PjBrbj75oqm8VlOoYQ==",
+      "version": "19.29.2",
+      "resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-19.29.2.tgz",
+      "integrity": "sha512-n7zuEgzTz70m5dmBqpYuE8zpeLKxgf73OeDudQWByNzIwWLb0I/UlxqdCLkk6Qb338O7em0aNuhVfExNBVCfTQ==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.1"
@@ -1275,9 +1275,9 @@
       "license": "MIT"
     },
     "node_modules/@sabaki/gtp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.1.0.tgz",
-      "integrity": "sha512-xNGoraSlFcmvT48zeo/UR1V0nmbNtcdhCX6YRrJERPQQLf9tKKZ6VG72aFogNT+88apiJZJKiIHE9Z70+9iDAw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.1.1.tgz",
+      "integrity": "sha512-Qm5XdlvBwkLBZNOmskSEn30hEOJ/H6xLh1qvgKAvkh71Sl15lghG/R27mGC0F5w8mmLqIgDnKqM8zhKFw3MDNg==",
       "license": "MIT"
     },
     "node_modules/@sabaki/i18n": {
@@ -1704,53 +1704,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -2749,13 +2702,6 @@
       "engines": {
         "node": ">=12.20"
       }
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -4079,16 +4025,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6973,19 +6909,27 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.28.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
-      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8694,22 +8638,17 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.1.tgz",
+      "integrity": "sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"
@@ -8718,16 +8657,30 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },
@@ -8737,13 +8690,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -112,11 +112,11 @@
   },
   "dependencies": {
     "@mariotacke/color-thief": "^3.0.1",
-    "@primer/octicons": "^19.29.1",
+    "@primer/octicons": "^19.29.2",
     "@sabaki/boardmatcher": "^1.2.0",
     "@sabaki/deadstones": "^2.2.0",
     "@sabaki/go-board": "^1.4.1",
-    "@sabaki/gtp": "^3.1.0",
+    "@sabaki/gtp": "^3.1.1",
     "@sabaki/i18n": "0.51.1-1",
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",
@@ -130,7 +130,7 @@
     "jschardet": "^3.0.0",
     "natsort": "^2.0.2",
     "pikaday": "^1.8.0",
-    "preact": "^10.4.0",
+    "preact": "^10.29.7",
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",
     "rimraf": "^6.1.2",
@@ -144,11 +144,11 @@
     "electron-builder": "^26.8.1",
     "mocha": "^11.7.6",
     "onchange": "^7.1.0",
-    "prettier": "3.8.1",
+    "prettier": "3.9.5",
     "tmp": "^0.2.7",
     "tsx": "^4.23.0",
     "webpack": "^5.108.4",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^7.2.1"
   },
   "scripts": {
     "test": "mocha --require tsx",


### PR DESCRIPTION
Batches the current Dependabot bumps into one PR. They all touch package.json / package-lock.json, so merging them individually just triggers a rebase + CI cascade.

- prettier 3.8.1 -> 3.9.5
- webpack-cli ^6.0.1 -> ^7.2.1
- @primer/octicons ^19.29.1 -> ^19.29.2
- @sabaki/gtp ^3.1.0 -> ^3.1.1
- preact ^10.4.0 -> ^10.29.7

Supersedes #1064, #1065, #1066, #1067, #1068.

Verified locally: production bundle (webpack-cli 7), `npm test` (89), and the full e2e suite (50 across all projects) all pass; format-check clean under prettier 3.9.5.
