### PR TITLE
Let custom background setting override themes

### DIFF
--- a/src/components/ThemeManager.js
+++ b/src/components/ThemeManager.js
@@ -174,7 +174,9 @@ export default class ThemeManager extends Component {
                 }`,
 
         backgroundPath != null &&
-          `main {
+          // Match theme selectors such as `#main main` so the user-selected
+          // background wins by source order instead of losing on specificity.
+          `#main main {
                     background-image: url('${backgroundPath.replace(
                       /\\/g,
                       '/',


### PR DESCRIPTION
Custom background images selected in Sabaki’s settings now can override the background included in theme. The css rule now has higher specificity.