### PR TITLE
Surface engine launch failures instead of failing silently

### DIFF
--- a/e2e/engine.spec.js
+++ b/e2e/engine.spec.js
@@ -195,4 +195,118 @@ test.describe('GTP Engine Integration Tests', () => {
     // Clean up
     await detachAndWait(page, syncerIds)
   })
+
+  // Regression coverage for #1083. A launch that fails used to surface only as
+  // an uncaught exception in the renderer: no dialog, no console entry, and an
+  // engine row that just sat there marked "Stopped".
+  test('reports an engine that cannot be spawned', async ({page}) => {
+    const pageErrors = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+
+    const missingPath = path.join(__dirname, 'fixtures', 'no-such-engine')
+
+    const syncerId = await page.evaluate((enginePath) => {
+      const [syncer] = window.__sabaki.attachEngines([
+        {name: 'MissingEngine', path: enginePath, args: ''},
+      ])
+      return syncer.id
+    }, missingPath)
+
+    await page.waitForFunction(
+      (id) => {
+        const syncer = window.__sabaki.state.attachedEngineSyncers.find(
+          (s) => s.id === id,
+        )
+        return syncer != null && syncer.error != null
+      },
+      syncerId,
+      {timeout: 10000},
+    )
+
+    const {error, suspended} = await page.evaluate((id) => {
+      const syncer = window.__sabaki.state.attachedEngineSyncers.find(
+        (s) => s.id === id,
+      )
+      return {error: syncer.error, suspended: syncer.suspended}
+    }, syncerId)
+
+    expect(error).toContain('Could not find the engine executable.')
+    expect(suspended).toBe(true)
+
+    // The reason has to reach the GTP console, not just DevTools.
+    const loggedError = await page.evaluate(() =>
+      window.__sabaki.state.consoleLog.some(
+        (entry) =>
+          entry.response != null &&
+          typeof entry.response.content === 'string' &&
+          entry.response.content.includes(
+            'Could not find the engine executable.',
+          ),
+      ),
+    )
+    expect(loggedError).toBe(true)
+
+    expect(pageErrors).toEqual([])
+
+    await detachAndWait(page, [syncerId])
+  })
+
+  test('reports an engine that exits immediately', async ({page}) => {
+    const pageErrors = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+
+    const failingEnginePath = path.resolve(
+      __dirname,
+      '..',
+      'test',
+      'engines',
+      'failingEngine.js',
+    )
+
+    const syncerId = await page.evaluate((enginePath) => {
+      const [syncer] = window.__sabaki.attachEngines([
+        {name: 'QuittingEngine', path: process.execPath, args: enginePath},
+      ])
+      return syncer.id
+    }, failingEnginePath)
+
+    await page.waitForFunction(
+      (id) => {
+        const syncer = window.__sabaki.state.attachedEngineSyncers.find(
+          (s) => s.id === id,
+        )
+        return syncer != null && syncer.error != null
+      },
+      syncerId,
+      {timeout: 10000},
+    )
+
+    const error = await page.evaluate(
+      (id) =>
+        window.__sabaki.state.attachedEngineSyncers.find((s) => s.id === id)
+          .error,
+      syncerId,
+    )
+
+    expect(error).toContain('exit code 3')
+
+    // The engine's own stderr is what actually explains a failure like this, so
+    // it has to make it into the console too. It can arrive either side of the
+    // exit, hence the separate wait.
+    await page.waitForFunction(
+      () =>
+        window.__sabaki.state.consoleLog.some(
+          (entry) =>
+            entry.response != null &&
+            typeof entry.response.content === 'string' &&
+            entry.response.content.includes('simulated startup failure'),
+        ),
+      undefined,
+      {timeout: 10000},
+    )
+
+    expect(pageErrors).toEqual([])
+
+    await detachAndWait(page, [syncerId])
+  })
 })

--- a/e2e/engine.spec.js
+++ b/e2e/engine.spec.js
@@ -255,17 +255,20 @@ test.describe('GTP Engine Integration Tests', () => {
     const pageErrors = []
     page.on('pageerror', (err) => pageErrors.push(err.message))
 
+    // Spawned directly rather than through process.execPath: that runs the
+    // Electron binary, whose sandbox startup races an immediate exit on Linux
+    // and kills the process by signal before it can return its own code.
     const failingEnginePath = path.resolve(
       __dirname,
       '..',
       'test',
       'engines',
-      'failingEngine.js',
+      'failingEngine.sh',
     )
 
     const syncerId = await page.evaluate((enginePath) => {
       const [syncer] = window.__sabaki.attachEngines([
-        {name: 'QuittingEngine', path: process.execPath, args: enginePath},
+        {name: 'QuittingEngine', path: enginePath, args: ''},
       ])
       return syncer.id
     }, failingEnginePath)
@@ -305,6 +308,50 @@ test.describe('GTP Engine Integration Tests', () => {
       {timeout: 10000},
     )
 
+    expect(pageErrors).toEqual([])
+
+    await detachAndWait(page, [syncerId])
+  })
+
+  test('reports an engine killed by a signal', async ({page}) => {
+    const pageErrors = []
+    page.on('pageerror', (err) => pageErrors.push(err.message))
+
+    const crashingEnginePath = path.resolve(
+      __dirname,
+      '..',
+      'test',
+      'engines',
+      'crashingEngine.sh',
+    )
+
+    const syncerId = await page.evaluate((enginePath) => {
+      const [syncer] = window.__sabaki.attachEngines([
+        {name: 'CrashingEngine', path: enginePath, args: ''},
+      ])
+      return syncer.id
+    }, crashingEnginePath)
+
+    await page.waitForFunction(
+      (id) => {
+        const syncer = window.__sabaki.state.attachedEngineSyncers.find(
+          (s) => s.id === id,
+        )
+        return syncer != null && syncer.error != null
+      },
+      syncerId,
+      {timeout: 10000},
+    )
+
+    const error = await page.evaluate(
+      (id) =>
+        window.__sabaki.state.attachedEngineSyncers.find((s) => s.id === id)
+          .error,
+      syncerId,
+    )
+
+    // A crash has no exit code, so the signal is the only thing identifying it.
+    expect(error).toContain('SIGSEGV')
     expect(pageErrors).toEqual([])
 
     await detachAndWait(page, [syncerId])

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sabaki/boardmatcher": "^1.2.0",
         "@sabaki/deadstones": "^2.2.0",
         "@sabaki/go-board": "^1.4.1",
-        "@sabaki/gtp": "^3.1.1",
+        "@sabaki/gtp": "^3.2.0",
         "@sabaki/i18n": "0.51.1-1",
         "@sabaki/immutable-gametree": "^1.9.4",
         "@sabaki/influence": "^1.2.2",
@@ -1333,9 +1333,9 @@
       "license": "MIT"
     },
     "node_modules/@sabaki/gtp": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.1.1.tgz",
-      "integrity": "sha512-Qm5XdlvBwkLBZNOmskSEn30hEOJ/H6xLh1qvgKAvkh71Sl15lghG/R27mGC0F5w8mmLqIgDnKqM8zhKFw3MDNg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sabaki/gtp/-/gtp-3.2.0.tgz",
+      "integrity": "sha512-KCOZ/fGvsSzzQ+XPEcrnNezrkNJVFjocah+V5K6qVasdYaT3L9ZSurRoTfjzizOpBSoxIPzsprPV2Zto6na+uQ==",
       "license": "MIT"
     },
     "node_modules/@sabaki/i18n": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@sabaki/boardmatcher": "^1.2.0",
     "@sabaki/deadstones": "^2.2.0",
     "@sabaki/go-board": "^1.4.1",
-    "@sabaki/gtp": "^3.1.1",
+    "@sabaki/gtp": "^3.2.0",
     "@sabaki/i18n": "0.51.1-1",
     "@sabaki/immutable-gametree": "^1.9.4",
     "@sabaki/influence": "^1.2.2",

--- a/src/components/sidebars/PeerList.js
+++ b/src/components/sidebars/PeerList.js
@@ -15,12 +15,14 @@ class EnginePeerListItem extends Component {
     this.state = {
       busy: props.syncer.busy,
       suspended: props.syncer.suspended,
+      error: props.syncer.error,
     }
 
     this.syncState = () => {
       this.setState({
         busy: this.props.syncer.busy,
         suspended: this.props.syncer.suspended,
+        error: this.props.syncer.error,
       })
     }
 
@@ -39,21 +41,36 @@ class EnginePeerListItem extends Component {
     this.props.syncer
       .on('busy-changed', this.syncState)
       .on('suspended-changed', this.syncState)
+      .on('error-changed', this.syncState)
   }
 
   componentWillUnmount() {
     this.props.syncer
       .removeListener('busy-changed', this.syncState)
       .removeListener('suspended-changed', this.syncState)
+      .removeListener('error-changed', this.syncState)
   }
 
   render({syncer, analyzing, selected, blackPlayer, whitePlayer}) {
+    let failed = this.state.error != null
+    let status = failed
+      ? t('Error')
+      : !this.state.suspended
+        ? t('Running')
+        : t('Stopped')
+    let statusIcon = failed
+      ? 'alert-16'
+      : !this.state.suspended
+        ? 'triangle-right-16'
+        : 'square-fill-16'
+
     return h(
       'li',
       {
         class: classnames('item', {
           analyzing,
           selected,
+          failed,
           busy: this.state.busy,
           suspended: this.state.suspended,
         }),
@@ -67,13 +84,11 @@ class EnginePeerListItem extends Component {
             'div',
             {
               class: 'icon',
-              title: !this.state.suspended ? t('Running') : t('Stopped'),
+              title: failed ? this.state.error : status,
             },
             h('img', {
-              src: `./node_modules/@primer/octicons/build/svg/${
-                !this.state.suspended ? 'triangle-right-16' : 'square-fill-16'
-              }.svg`,
-              alt: !this.state.suspended ? t('Running') : t('Stopped'),
+              src: `./node_modules/@primer/octicons/build/svg/${statusIcon}.svg`,
+              alt: status,
             }),
           )
         : h(TextSpinner),

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -10,7 +10,7 @@ import {parseCompressedVertices} from '@sabaki/sgf'
 
 import i18n from '../i18n.js'
 import {getBoard, getRootProperty} from './gametree.js'
-import {noop, equals} from './helper.js'
+import {equals} from './helper.js'
 import {parseAnalysis} from './analysis.js'
 
 const t = i18n.context('EngineSyncer')
@@ -20,6 +20,7 @@ const setting = {
 
 const alpha = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
 const quitTimeout = setting.get('gtp.engine_quit_timeout')
+const stderrBufferSize = 10
 
 function parseVertex(coord, size) {
   if (coord == null || coord === 'resign') return null
@@ -40,6 +41,9 @@ export default class EngineSyncer extends EventEmitter {
     this._busy = false
     this._suspended = true
     this._analysis = null
+    this._error = null
+    this._stopRequested = false
+    this._stderr = []
 
     this.id = uuid()
     this.engine = engine
@@ -68,9 +72,15 @@ export default class EngineSyncer extends EventEmitter {
 
     this.stateTracker = new ControllerStateTracker(this.controller)
 
+    this.controller.on('stderr', ({content}) => {
+      this._stderr = [...this._stderr, content].slice(-stderrBufferSize)
+    })
+
     this.controller.on('started', () => {
       this.treePosition = null
       this.analysis = null
+      this.error = null
+      this._stderr = []
 
       Promise.all([
         this.controller.sendCommand({name: 'name'}),
@@ -89,12 +99,24 @@ export default class EngineSyncer extends EventEmitter {
                 this.controller.sendCommand(Command.fromString(command)),
               )
           : []),
-      ]).catch(noop)
+      ]).catch(() => {
+        // A dead process is reported by the 'stopped' handler below; a live one
+        // that fails the handshake isn't speaking GTP.
+        if (this.controller.process != null && !this._stopRequested) {
+          this.error = t('The engine did not respond to the GTP handshake.')
+        }
+      })
     })
 
-    this.controller.on('stopped', () => {
+    this.controller.on('stopped', ({code, error}) => {
       this.treePosition = null
       this.analysis = null
+
+      if (!this._stopRequested) {
+        this.error = this._describeFailure({code, error})
+      }
+
+      this._stopRequested = false
     })
 
     this.controller.on(
@@ -210,11 +232,44 @@ export default class EngineSyncer extends EventEmitter {
     }
   }
 
+  get error() {
+    return this._error
+  }
+
+  set error(value) {
+    if (value !== this._error) {
+      this._error = value
+      this.emit('error-changed')
+    }
+  }
+
+  _describeFailure({code, error}) {
+    let reason =
+      error == null
+        ? code == null
+          ? t('The engine stopped unexpectedly.')
+          : t((p) => `The engine stopped unexpectedly (exit code ${p.code}).`, {
+              code,
+            })
+        : error.code === 'ENOENT'
+          ? t('Could not find the engine executable.')
+          : error.code === 'EACCES' || error.code === 'EISDIR'
+            ? t('The engine executable cannot be run.')
+            : error.message
+
+    // Engines often sign off with a usage block or a blank line, so quote back
+    // the last line that actually says something.
+    let lastLine = this._stderr.filter((line) => line.trim() !== '').pop()
+
+    return lastLine == null ? reason : `${reason}\n\n${lastLine}`
+  }
+
   start() {
     this.controller.start()
   }
 
   async stop() {
+    this._stopRequested = true
     await this.controller.stop(quitTimeout)
   }
 

--- a/src/modules/enginesyncer.js
+++ b/src/modules/enginesyncer.js
@@ -10,7 +10,7 @@ import {parseCompressedVertices} from '@sabaki/sgf'
 
 import i18n from '../i18n.js'
 import {getBoard, getRootProperty} from './gametree.js'
-import {equals} from './helper.js'
+import {noop, equals} from './helper.js'
 import {parseAnalysis} from './analysis.js'
 
 const t = i18n.context('EngineSyncer')
@@ -108,12 +108,12 @@ export default class EngineSyncer extends EventEmitter {
       })
     })
 
-    this.controller.on('stopped', ({code, error}) => {
+    this.controller.on('stopped', ({code, signal, error}) => {
       this.treePosition = null
       this.analysis = null
 
       if (!this._stopRequested) {
-        this.error = this._describeFailure({code, error})
+        this.error = this._describeFailure({code, signal, error})
       }
 
       this._stopRequested = false
@@ -243,14 +243,17 @@ export default class EngineSyncer extends EventEmitter {
     }
   }
 
-  _describeFailure({code, error}) {
+  _describeFailure({code, signal, error}) {
     let reason =
       error == null
-        ? code == null
-          ? t('The engine stopped unexpectedly.')
-          : t((p) => `The engine stopped unexpectedly (exit code ${p.code}).`, {
-              code,
-            })
+        ? signal != null
+          ? t((p) => `The engine was terminated by ${p.signal}.`, {signal})
+          : code == null
+            ? t('The engine stopped unexpectedly.')
+            : t(
+                (p) => `The engine stopped unexpectedly (exit code ${p.code}).`,
+                {code},
+              )
         : error.code === 'ENOENT'
           ? t('Could not find the engine executable.')
           : error.code === 'EACCES' || error.code === 'EISDIR'
@@ -266,6 +269,12 @@ export default class EngineSyncer extends EventEmitter {
 
   start() {
     this.controller.start()
+
+    // Writing to an engine that has just died surfaces as an asynchronous EPIPE
+    // on the pipe rather than at the call site, and an unhandled stream error
+    // would take the renderer down. The death itself is reported via 'stopped'.
+    let {stdin} = this.controller.process || {}
+    if (stdin != null) stdin.on('error', noop)
   }
 
   async stop() {

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -1882,7 +1882,18 @@ class Sabaki extends EventEmitter {
     for (let engine of engines) {
       engine = {...engine, name: getEngineName(engine.name)}
 
-      let syncer = new EngineSyncer(engine)
+      let syncer
+      try {
+        syncer = new EngineSyncer(engine)
+      } catch (err) {
+        dialog.showMessageBox(
+          t((p) => `Could not attach ${p.name}.`, {name: engine.name}) +
+            `\n\n${err.message}`,
+          'warning',
+        )
+
+        continue
+      }
 
       syncer.on('analysis-update', () => {
         if (this.state.analyzingEngineSyncerId === syncer.id) {
@@ -1981,6 +1992,29 @@ class Sabaki extends EventEmitter {
           message: 'Engine Stopped',
           engine: engine.name,
         })
+      })
+
+      syncer.on('error-changed', () => {
+        if (syncer.error == null) return
+
+        this.setState(({consoleLog}) => ({
+          consoleLog: [
+            ...consoleLog,
+            {
+              name: engine.name,
+              command: null,
+              response: {content: syncer.error, internal: true},
+            },
+          ],
+        }))
+
+        gtplogger.write({
+          type: 'meta',
+          message: `Engine Error: ${syncer.error}`,
+          engine: engine.name,
+        })
+
+        dialog.showMessageBox(`${engine.name}\n\n${syncer.error}`, 'warning')
       })
 
       syncer.controller.start()

--- a/src/modules/sabaki.js
+++ b/src/modules/sabaki.js
@@ -2017,7 +2017,7 @@ class Sabaki extends EventEmitter {
         dialog.showMessageBox(`${engine.name}\n\n${syncer.error}`, 'warning')
       })
 
-      syncer.controller.start()
+      syncer.start()
 
       attaching.push(syncer)
     }

--- a/style/index.css
+++ b/style/index.css
@@ -1206,7 +1206,7 @@ header {
     font-size: 1em;
     font-weight: normal;
   }
-  .engines-list li h3 + p input {
+  .engines-list li h3 + p input:placeholder-shown {
     opacity: .5;
   }
   .engines-list li > * { margin: 0; }
@@ -1241,6 +1241,8 @@ header {
   .engines-list li a.remove:active {
     background: #C60001;
   }
+  .engines-list li a.browse:hover,
+  .engines-list li a.browse:focus,
   .engines-list li a.browse:active {
     opacity: 1;
 }
@@ -1359,6 +1361,9 @@ header {
     width: 1.5em;
     filter: invert(100%);
     opacity: .6;
+  }
+  .engine-peer-list .item.failed .icon {
+    opacity: 1;
   }
   .engine-peer-list .item .icon.player {
     filter: none;

--- a/test/engines/crashingEngine.sh
+++ b/test/engines/crashingEngine.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Stands in for an engine that crashes rather than exiting, so the process is
+# killed by a signal and has no exit code to report.
+echo "crashingEngine: simulated crash" >&2
+kill -SEGV $$

--- a/test/engines/failingEngine.js
+++ b/test/engines/failingEngine.js
@@ -1,0 +1,6 @@
+// Stands in for an engine that spawns but dies before it can speak GTP — a
+// missing shared library, or KataGo invoked without its `gtp` subcommand, as in
+// SabakiHQ/Sabaki#1083.
+
+process.stderr.write('failingEngine: simulated startup failure\n')
+process.exit(3)

--- a/test/engines/failingEngine.js
+++ b/test/engines/failingEngine.js
@@ -1,6 +1,0 @@
-// Stands in for an engine that spawns but dies before it can speak GTP — a
-// missing shared library, or KataGo invoked without its `gtp` subcommand, as in
-// SabakiHQ/Sabaki#1083.
-
-process.stderr.write('failingEngine: simulated startup failure\n')
-process.exit(3)

--- a/test/engines/failingEngine.sh
+++ b/test/engines/failingEngine.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Stands in for an engine that spawns but dies before it can speak GTP -- a
+# missing shared library, or KataGo invoked without its `gtp` subcommand, as in
+# SabakiHQ/Sabaki#1083.
+echo "failingEngine: simulated startup failure" >&2
+exit 3


### PR DESCRIPTION
Fixes #1083, or at least the diagnostics half of it.

When a process can't be launched, Node reports it as an `error` event on the child. Nothing was listening for it, and an unhandled `error` event throws -- in the renderer, where there's no handler, so it landed in devtools and nowhere a user would look. No dialog, no GTP console entry, no log line. `Controller` also emitted `started` before knowing whether the process had come up, and the initial GTP handshake was wrapped in `.catch(noop)`, so all three places that could have reported the failure stayed quiet.

The dependency side of this is @sabaki/gtp 3.2.0 (SabakiHQ/gtp#14), bumped here: a failed spawn is reported on `stopped` as `{code, signal, error}` rather than thrown, and `started` only fires once the process is actually up.

On top of that:

- `EngineSyncer` gets an `error` state alongside `busy`/`suspended`, plus a small rolling stderr buffer so the last meaningful line can be quoted with the error. ENOENT and EACCES get plain-language text; an engine that spawns and then dies reports its exit code. Stopping an engine deliberately isn't reported as a failure.
- `attachEngines` puts the error in the GTP console, the GTP log and a message box, and wraps the `EngineSyncer` constructor in a try/catch, since `resolve()` and `argvsplit()` both throw on a saved engine with a null path or args.
- `PeerList` renders a failed engine with an alert icon and the reason as its tooltip.
- Two CSS fixes prompted by the screenshots in #1083: the engine path input sat at 50% opacity even when it had a value, so a configured path looked disabled next to the arguments below it, and the browse button only reached full opacity on `:active`, never `:hover`.

Deliberately not covered: an engine that starts and then never answers. A handshake timeout would misfire on KataGo loading a large model on CPU, and a wrong "your engine is broken" is worse than staying quiet. If it's worth closing later I think it wants a distinct "waiting" state in the sidebar rather than a timeout.

89 unit tests and all 52 e2e specs pass against the published 3.2.0. Two new engine specs cover a path that can't be spawned and an engine that exits immediately, both asserting no uncaught renderer error. I also ran it by hand against four stand-in broken katagos -- missing shared library, missing `gtp` subcommand, non-executable file, path that doesn't exist -- and checked the message each one produces.